### PR TITLE
Lint the project content against common standards

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -8,6 +8,13 @@ on:
 
 jobs:
   build:
+    # Permissions required for golangci-lint to push its status checks back to GitHub.
+    # See https://github.com/golangci/golangci-lint-action
+    permissions:
+      contents: read
+      pull-requests: read
+      checks: write
+
     name: "test"
     # The machine type on which the workload is running
     # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#choosing-github-hosted-runners
@@ -36,3 +43,6 @@ jobs:
     # Test
     - name: Test
       run: task test
+
+    - name: "Lint"
+      uses: golangci/golangci-lint-action@v3

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -116,6 +116,11 @@ tasks:
     cmds:
       - "tofu apply next.planfile"
 
+  lint:
+    desc: "Validate the code against common standards"
+    cmds:
+      - golangci-lint run ./...
+
   test:
     env:
       CGO_ENABLED: 1

--- a/cmd/redirect/serve_test.go
+++ b/cmd/redirect/serve_test.go
@@ -42,13 +42,15 @@ func TestGetStorage(t *testing.T) {
 					panic(err)
 				}
 
-				file.Write([]byte(`
+				if _, err := file.Write([]byte(`
 ---
 - from: //x40/foo
   to: //k3s/bar
 - from: //x40/bar
   to: //k3s/baz
-`))
+`)); err != nil {
+					panic(err)
+				}
 				file.Close()
 			},
 		},
@@ -65,7 +67,7 @@ func TestGetStorage(t *testing.T) {
 			}
 
 			// Replicate the supplied user option.
-			serveFlagSet.Set(tc.fName, tc.fVal)
+			assert.Nil(t, serveFlagSet.Set(tc.fName, tc.fVal))
 
 			_, err := getStorage(serveFlagSet)
 			assert.ErrorIs(t, tc.err, err)

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -3,7 +3,7 @@ package configuration
 
 const (
 	// Storage* is configuration related to the link storage logic.
-	StorageYamlFile = "storage.yaml.file"
-	StorageHashMap  = "storage.hash-map"
-	StoreBoltDBFile = "store.boltdb.file"
+	StorageYamlFile   = "storage.yaml.file"
+	StorageHashMap    = "storage.hash-map"
+	StorageBoltDBFile = "store.boltdb.file"
 )

--- a/storage/memory/hash_table_test.go
+++ b/storage/memory/hash_table_test.go
@@ -2,6 +2,7 @@ package memory_test
 
 import (
 	"fmt"
+	"log"
 	"net/url"
 	"testing"
 
@@ -33,7 +34,10 @@ func ExampleNewHashTable() {
 		from, _ := url.Parse(tu.f)
 		to, _ := url.Parse(tu.t)
 
-		ht.Put(from, to)
+		err := ht.Put(from, to)
+		if err != nil {
+			log.Println(err)
+		}
 	}
 
 	// Lookup a value supplied by the user
@@ -50,11 +54,11 @@ func TestNewHashTable(t *testing.T) {
 	t.Parallel()
 
 	ht := memory.NewHashTable()
-	ht.Put(&url.URL{
+	assert.Nil(t, ht.Put(&url.URL{
 		Host: "x40",
 	}, &url.URL{
 		Host: "andrewhowden.com",
-	})
+	}))
 
 	res, err := ht.Get(&url.URL{
 		Host: "x40",

--- a/storage/yaml/yaml_test.go
+++ b/storage/yaml/yaml_test.go
@@ -127,8 +127,9 @@ func TestLoggerOverride(t *testing.T) {
 		Level: slog.LevelDebug,
 	}))
 
-	// Get an error condition (failed URL)
-	yaml.New(memory.NewHashTable(), bytes.NewBufferString(`
+	// Get an error condition (failed URL). Return values are discarded as they are (implicitly) validated via the
+	// log assertion.
+	_, _ = yaml.New(memory.NewHashTable(), bytes.NewBufferString(`
 - from: "//	/foo"
   to: //k3s/bar
 `))


### PR DESCRIPTION
This commit extends the existing status checks the software validated against to include "golangci-lints", with the default set of lints. These allow picking up common issues that can introduce bugs, but that are not found (so far) in unit tests.

== Design Notes
=== Task vs. Action

The action for GitHub allows pushing the statuses back to the checks API. Given this, its used instead of using task for the same purpose.