### PR TITLE
Define, validate and upload container

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,60 @@
+FROM docker.io/library/golang:1.21 AS build
+ARG GOARCH="amd64"
+
+ENV TASK_VERSION="v3.33.1"
+ENV GOOS="linux" GOARCH="${GOARCH}"
+
+# Install the task runner
+RUN curl \
+        --output /tmp/task.tar.gz \
+        --location \
+        "https://github.com/go-task/task/releases/download/$TASK_VERSION/task_linux_amd64.tar.gz" \
+    && tar \
+        --directory /tmp \
+        --extract \
+        --file /tmp/task.tar.gz \
+    && chmod +x /tmp/task \
+    && mv /tmp/task /usr/bin/task && \
+    rm -rf /tmp/*
+
+# Copy in the source files
+WORKDIR /mnt
+COPY . /mnt
+
+# Build the binary
+RUN task bin
+
+# An imagine with SSL certificates (and some other Linux niceties)
+# See
+# * https://github.com/GoogleContainerTools/distroless/blob/main/base/README.md
+# * https://console.cloud.google.com/gcr/images/distroless/GLOBAL/static
+#
+# Ignore the image pinning requirement — distroless is essentialy empty.
+# hadolint ignore=DL3007
+FROM gcr.io/distroless/static:latest AS run
+
+# For the standard OCI Labels
+
+# The standard OCI Labels. See:
+# https://github.com/opencontainers/image-spec/blob/main/annotations.md
+ARG VERSION="dev"
+ARG CREATED="1970-01-01"
+
+LABEL "org.opencontainers.image.title"="x40.link" \
+    org.opencontainers.image.description="The server for the @.link shortening service" \
+    org.opencontainers.image.created="${CREATED}" \
+    org.opencontainers.image.authors="Andrew Howden <hello@andrewhowden.com>" \
+    org.opencontainers.image.url="https://www.x40.dev/" \
+    org.opencontainers.image.documentation="https://www.x40.dev/" \
+    org.opencontainers.image.source="https://github.com/andrewhowdencom/x40.link/tree/main/Containerfile" \
+    org.opencontainers.image.version="${VERSION}" \
+    org.opencontainers.image.revision="${VERSION}" \
+    org.opencontainers.image.vendor="Andrew Howden <hello@andrewhowden.com>" \
+    org.opencontainers.image.licenses="AGPL"
+
+
+ENV GOOS="linux"
+
+COPY --from=build /mnt/dist/linux+${GOARCH}/x40.link /usr/bin/x40.link
+
+CMD ["/usr/bin/x40.link", "redirect", "serve", "--with-boltdb", "/tmp/urls.db"]

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -6,6 +6,10 @@ env:
   # Disable calls to CGO, so that the binaries compiled are static.
   CGO_ENABLED: "0"
 
+vars:
+  GIT_REFSPEC:
+    sh: "git rev-parse --short HEAD"
+
 tasks:
   bin:
     desc: "Build a go binary specific to an architecture and operating system"
@@ -57,6 +61,16 @@ tasks:
     desc: "Clean the generated artifacts"
     cmds:
       - "rm -rf dist"
+
+  container:
+    desc: "Build the container for the application"
+    cmds:
+      - |
+        podman build \
+          --build-arg VERSION="{{ .GIT_REFSPEC }}" \
+          --build-arg CREATED='{{now | date "2006-01-02T15:04:05Z07:00"}}' \
+          --tag x40.link:{{ .GIT_REFSPEC }} \
+          .
 
   docs:
     desc: "Build the static HTML for the documentation"
@@ -119,6 +133,10 @@ tasks:
   lint:
     desc: "Validate the code against common standards"
     cmds:
+      # Containers
+      - hadolint Containerfile
+
+      # Golang
       - golangci-lint run ./...
 
   test:

--- a/cmd/redirect/serve.go
+++ b/cmd/redirect/serve.go
@@ -37,7 +37,7 @@ var (
 	serveFlagSet = &pflag.FlagSet{}
 )
 
-var strFlags = []string{flagStrHashMap, flagStrYAML}
+var strFlags = []string{flagStrHashMap, flagStrYAML, flagStrBoltDB}
 
 // Serve starts the HTTP server that will redirect a given HTTP request to a destination.
 var Serve = &cobra.Command{

--- a/docs/content/reference/code/requirements.md
+++ b/docs/content/reference/code/requirements.md
@@ -26,13 +26,17 @@ The following are programmed in:
 
 The following are the tools used to build, deploy, maintain, code etc.
 
-| Tool     | Purpose                                                                                                  |
-|:---------|:---------------------------------------------------------------------------------------------------------|
-| [poetry] | Manage dependencies & virtual environments in Python                                                     |
-| [task]   | Run defined tasks                                                                                        |
-| [tar]    | Compress directories into archives                                                                       |
-| [tofu]   | Deploy infrastructure as code                                                                            |
+| Tool       | Purpose                                                                                                |
+|:---------- |:-------------------------------------------------------------------------------------------------------|
+| [hadolint] | Lint the Dockerfile                                                                                    |
+| [podman]   | Build containers                                                                                       |
+| [poetry]   | Manage dependencies & virtual environments in Python                                                   |
+| [task]     | Run defined tasks                                                                                      |
+| [tar]      | Compress directories into archives                                                                     |
+| [tofu]     | Deploy infrastructure as code                                                                          |
 
+[handolint]: https://github.com/hadolint/hadolint
+[podman]: https://podman.io/
 [poetry]: https://python-poetry.org/
 [task]: https://taskfile.dev/
 [tar]: https://www.gnu.org/software/tar/


### PR DESCRIPTION
While the application currently gets built (and stored in the dist
folder), there is currently not a sufficient package for the application
to be deployed to a production environment.

This commit provides one by packing the application into an OCI
container.

== Design Notes
=== Multi-step builds

The commit uses a multi-step build¹ to first build the binary, and then
copy the binary into a new container with a minimal root filesystem.
This, in principle, allows for a much smaller attack service assuming
_somehow_ an attacker managed to get an RCE within a go application (a
tall order).

In practice, this just allows nice small images.

=== Podman

This commit uses the project "Podman" created by RedHat and donated to
the CNCF as its container tooling. Podman is daemonless, rootless and
allows building and running containers.

It is used instead of Docker as Docker recently imposed some new limits
on the usage of its software, similar to Hashicorp, and I have a
tendency to avoid things unless I understand them.

=== Image Tag

The image tag is the shortref from git. This should be stable, allow a
quick link to Git and shift as the underlying software (or anything
else in the repository) shifts.

=== Imagine Labels

The imagine is enriched with a series of standard "image labels", which
can provide metadata to systems interested in the image itself.

=== Hadolint

Containers are written in a language which is a "psuedo-bash" like
— partially declarative, partially imperative. They inherit the
shortfalls of bash, which can be many.

Given this, this commit includes a linter ("hadolint") for the file.
This linter was chosen simply after scanning a couple of blog posts that
recommend it.

It picked up the distroless image not having a tag, which was
subsequently added (with the sha)

== Links

1. https://docs.docker.com/build/building/multi-stage/
2. https://podman.io/