### PR TITLE
Add the h4n.me domain

### DIFF
--- a/deploy/prod/tf/dns.tf
+++ b/deploy/prod/tf/dns.tf
@@ -12,6 +12,12 @@ resource "google_dns_managed_zone" "x40-dev" {
   description = "The developer documentation for the x40 project."
 }
 
+resource "google_dns_managed_zone" "h4n-me" {
+  name        = "h4n-me"
+  dns_name    = "h4n.me."
+  description = "A short domain for 'Howden'"
+}
+
 resource "google_dns_record_set" "x40-dev__ALIAS" {
   managed_zone = google_dns_managed_zone.x40-dev.name
   name         = google_dns_managed_zone.x40-dev.dns_name


### PR DESCRIPTION
This work started originally with the goal to replace the h4n.link domain. That domain is being transferred to another party with the intent to use it better than I can, so I'll replace it with h4n.me. That third party has gratiously agreed to 301 all the links from h4n.link to h4n.me that already exist.

This commit adds h4n.me to the managed domains, such that there can be nameservers and these can be updated in Gandi. Future work will add these domains to the link shortener as early tests (via the Yaml backend, probably).