### PR TITLE
Limit pipeline execution to changes

### DIFF
--- a/.github/workflows/main+documentation.yml
+++ b/.github/workflows/main+documentation.yml
@@ -12,6 +12,21 @@ jobs:
     # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#choosing-github-hosted-runners
     runs-on: ubuntu-22.04
     steps:
+      - name: Checkout the main branch
+        uses: actions/checkout@v4
+
+      - name: Exit if there are no docs changes
+        run: |
+          # Determine if there are any changes
+          git diff HEAD~1..HEAD --name-only | grep docs \
+              || {
+                  gh run cancel ${{ github.run_id }};
+                  gh run watch ${{ github.run_id }};
+              }
+
+          # If the watch (somehow) fails, kill the pipeline here anyway as failed.
+          exit 1
+
       # Setup Python (& Dependencies)
       - name: "Setup Python"
         uses: actions/setup-python@v5
@@ -24,9 +39,6 @@ jobs:
       # Install the Task Runner
       - name: Install Task
         uses: arduino/setup-task@v1
-
-      - name: Checkout the main branch
-        uses: actions/checkout@v4
 
       # Generate the documentation
       - name: "Build the documentation artifact"

--- a/.github/workflows/main+x40.link.yml
+++ b/.github/workflows/main+x40.link.yml
@@ -27,6 +27,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Exit if there are no code changes
+        run: |
+          # Determine if there are any changes
+          git diff HEAD~1..HEAD --name-only | grep -E "Containerfile|.go" \
+              || {
+                  gh run cancel ${{ github.run_id }};
+                  gh run watch ${{ github.run_id }};
+              }
+
+          # If the watch (somehow) fails, kill the pipeline here anyway as failed.
+          exit 1
       # See https://github.com/redhat-actions/podman-login
       - name: Log in to ghcr.io
         uses: redhat-actions/podman-login@v1


### PR DESCRIPTION
Currently, the pipelines are executing every merge to main. This is producing a lot of artifacts, even though nothing changes. There are a couple of choices here:

1. Use a specific marker (e.g. a tag) to indicate that a release is necessary
2. Run the pipeline conditionally, depending on the changes in the request.

This commit takes the latter approach. This should allow a nice "deploy to master" style approach, but also limit the number of artifacts generated. It also should clearly indicate which pipelines are skipped as the tool uses the GitHub API to skip them.

== Design Notes
=== Not using dorny/paths-filter

There's a ... lot of code in this workflow, and I don't know the author. Given this, I'm choosing a simpler approach for now. See:

* https://github.com/dorny/paths-filter