### PR TITLE
Make the existing links for h4n.me work

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -52,8 +52,10 @@ LABEL "org.opencontainers.image.title"="x40.link" \
     org.opencontainers.image.licenses="AGPL"
 
 
+
 ENV GOOS="linux"
 
 COPY --from=build /mnt/dist/linux+${GOARCH}/x40.link /usr/bin/x40.link
+COPY etc/urls.yaml /urls.yaml
 
-CMD ["/usr/bin/x40.link", "redirect", "serve", "--with-boltdb", "/tmp/urls.db"]
+CMD ["/usr/bin/x40.link", "redirect", "serve", "--with-yaml", "/urls.yaml"]

--- a/cmd/redirect/serve.go
+++ b/cmd/redirect/serve.go
@@ -6,6 +6,7 @@ package redirect
 import (
 	"errors"
 	"fmt"
+	"log"
 	"net/http"
 	"net/url"
 	"os"
@@ -90,10 +91,13 @@ func RunServe(cmd *cobra.Command, args []string) error {
 		// TODO: Figure out a saner way to do this
 		url := &url.URL{
 			// There's no support for anything else at this time
-			Scheme: "http",
-			Host:   r.Host,
-			Path:   r.URL.Path,
+			Host: r.Host,
+			Path: r.URL.Path,
 		}
+
+		// Temporary for debugging in production
+		log.Println(url.String())
+
 		ret, err := str.Get(url)
 
 		// Iterate though the potential failure modes.
@@ -109,7 +113,7 @@ func RunServe(cmd *cobra.Command, args []string) error {
 		w.WriteHeader(http.StatusTemporaryRedirect)
 	})
 
-	return http.ListenAndServe("0.0.0.0:8080", http.DefaultServeMux)
+	return http.ListenAndServe("0.0.0.0:80", http.DefaultServeMux)
 }
 
 // getStorage fetches the appropriate storage for the supplied configuration. Assumes that at least one configuration

--- a/storage/yaml/yaml.go
+++ b/storage/yaml/yaml.go
@@ -59,6 +59,8 @@ func New(str storage.Storer, src io.Reader) (*yaml, error) {
 			continue
 		}
 
+		fmt.Println(from.String(), to.String())
+
 		if err := y.str.Put(from, to); err != nil {
 			return nil, fmt.Errorf("%w: %s", storage.ErrStorageSetupFailed, err)
 		}


### PR DESCRIPTION
In parallel to this project work, there's the deprecation of the h4n.link domain and replacement with h4n.me. This commit is a bit of a hack — introducing configuration into the containerfile directly — but it is Friday, and I want to get this done before the weekend.

Future work should remove this content in favour of a firebase datastore backend.