### PR TITLE
Issue certificates for h4n.me

### DIFF
--- a/deploy/prod/tf/cr.tf
+++ b/deploy/prod/tf/cr.tf
@@ -52,7 +52,7 @@ resource "google_dns_record_set" "x40-link" {
 }
 
 resource "google_dns_record_set" "h4n-me" {
-  for_each     = toset(["h4n.me", "www.h4n.me"])
+  for_each     = toset(var.h4n_me_domains)
   name         = "${each.value}."
   managed_zone = google_dns_managed_zone.h4n-me.name
   ttl          = 300
@@ -68,11 +68,11 @@ resource "google_compute_global_address" "x40-link" {
   name = "x40-link"
 }
 
-resource "google_compute_managed_ssl_certificate" "x40-link" {
-  name = "x40-link"
+resource "google_compute_managed_ssl_certificate" "all-link-shorteners" {
+  name = "all-link-shorteners"
 
   managed {
-    domains = var.x40_link_domains
+    domains = concat(var.x40_link_domains, var.h4n_me_domains)
   }
 }
 
@@ -106,7 +106,7 @@ resource "google_compute_target_https_proxy" "x40-link" {
   url_map = google_compute_url_map.x40-link.id
 
   ssl_certificates = [
-    google_compute_managed_ssl_certificate.x40-link.id
+    google_compute_managed_ssl_certificate.all-link-shorteners.id
   ]
 }
 

--- a/deploy/prod/tf/vars.tf
+++ b/deploy/prod/tf/vars.tf
@@ -3,6 +3,11 @@ variable "x40_link_domains" {
   default = ["x40.link", "www.x40.link", "app.x40.link", "api.x40.link"]
 }
 
+variable "h4n_me_domains" {
+    type = list(string)
+    default = ["h4n.me", "www.h4n.me"]
+}
+
 variable "cloud-run__x40-link" {
   type    = string
   default = "x40-link"


### PR DESCRIPTION
Currently, the certificates generated by the application are only valid for x40.link. With the personal use of h4n.me, this means those links are unusable. This commit addresses that by making these links usable again