### PR TITLE
Introduce a flag to customize the listen address

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -58,4 +58,4 @@ ENV GOOS="linux"
 COPY --from=build /mnt/dist/linux+${GOARCH}/x40.link /usr/bin/x40.link
 COPY etc/urls.yaml /urls.yaml
 
-CMD ["/usr/bin/x40.link", "redirect", "serve", "--with-yaml", "/urls.yaml"]
+CMD ["/usr/bin/x40.link", "redirect", "serve", "--with-yaml", "/urls.yaml", "--listen-address", "0.0.0.0:80"]

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -6,4 +6,7 @@ const (
 	StorageYamlFile   = "storage.yaml.file"
 	StorageHashMap    = "storage.hash-map"
 	StorageBoltDBFile = "store.boltdb.file"
+
+	// Server* is configuration that modifies how the server is run
+	ServerListenAddress = "server.listen-address"
 )

--- a/deploy/prod/cr/service.yaml
+++ b/deploy/prod/cr/service.yaml
@@ -19,3 +19,9 @@ spec:
       timeoutSeconds: 1
       containers:
         - image: europe-west3-docker.pkg.dev/andrewhowdencom/x40-link/x40.link:$VERSION
+          command: ["/usr/bin/x40.link"]
+          args: 
+            - "redirect"
+            - "serve"
+            - "--with-yaml='/urls.yaml'"
+            - "--listen-address='0.0.0.0:8080'"


### PR DESCRIPTION
Currently there is a problem when running the application across
different environments: The default port requirements are different.
For example,

  On Google Cloud: The default port should be 8080 (and bound to all
                   ports) so that Google Cloud Run will send the
                   traffic to the place it is expected
  Locally:         The default port should be 80, so the browser will
                   send traffic to the default HTTP port

This commit reconciles these differences by allowing the port to be
specified when the application is invoked via the "--listen-address"
flag.

== Design Notes
=== Default Value

The default value for this application has also been altered to listen
on localhost, as this is anticipated to be the most frequent way the
application is invoked (by third parties, or people running it on
localhost).

This means the default value will no longer work in either the container
nor on Google Cloud. This means they're also adjusted
(in the Containerfile and in the knative specification)

=== No tests

The code that invokes the server is fragile, and not written in a way that
can easily be tested. Fortunately, that code was written largely to get
a proof of concept up and running, and will be refactored. In future,
this will be tested with the rest of the server package.

Given this, for now the tests are skipped.
