### PR TITLE
Fix the arguments in the service invocation

### DIFF
--- a/deploy/prod/cr/service.yaml
+++ b/deploy/prod/cr/service.yaml
@@ -23,5 +23,5 @@ spec:
           args: 
             - "redirect"
             - "serve"
-            - "--with-yaml='/urls.yaml'"
-            - "--listen-address='0.0.0.0:8080'"
+            - "--with-yaml=/urls.yaml"
+            - "--listen-address=0.0.0.0:8080"


### PR DESCRIPTION
In recent work (980057a), the default listen address for the
application was changed, and the invocation adjusted in the cloud run
definition.

Unfortunately, this broke the definition — the way the arguments are
specified is:

   "--with-yaml='/urls.yaml'"

Which, apparently, is not subject to the bash expansion as expected
(where it should be):

    --with-yaml='urls.yaml'

This commit removes the inner set of quotes, as they're unnecessary if
the whole string is treated as a single argument.
