### PR TITLE
Enable the revive linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,13 @@
+linters:
+  enable:
+    - revive
+
+issues:
+  exclude-use-default: false
+
+  exclude-rules:
+    # Here, we're explicitly allowing unexported types. This is a common type where we definitely do not want people
+    # extending or embedding the interface, such as test types.
+    - linters:
+      - revive
+      text: ".*returns unexported type.*"

--- a/cmd/redirect.go
+++ b/cmd/redirect.go
@@ -1,6 +1,3 @@
-/*
-Copyright © 2023 Andrew Howden <hello@andrewhowden.com>
-*/
 package cmd
 
 import (

--- a/cmd/redirect/serve.go
+++ b/cmd/redirect/serve.go
@@ -1,6 +1,4 @@
-/*
-Copyright © 2023 Andrew Howden <hello@andrewhowden.com>
-*/
+// Package redirect provides the commands associated with redirecting users
 package redirect
 
 import (
@@ -82,7 +80,8 @@ func init() {
 	Serve.MarkFlagsMutuallyExclusive(storageFlags...)
 }
 
-func RunServe(cmd *cobra.Command, args []string) error {
+// RunServe implements the run server command
+func RunServe(cmd *cobra.Command, _ []string) error {
 	str, err := getStorage(cmd.Flags())
 	if err != nil {
 		return fmt.Errorf("%w: %s", sysexits.Software, err)

--- a/cmd/redirect/serve_test.go
+++ b/cmd/redirect/serve_test.go
@@ -51,7 +51,10 @@ func TestGetStorage(t *testing.T) {
 `)); err != nil {
 					panic(err)
 				}
-				file.Close()
+
+				if err := file.Close(); err != nil {
+					panic(err)
+				}
 			},
 		},
 	} {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,12 +1,11 @@
-/*
-Copyright © 2023 Andrew Howden <hello@andrewhowden.com>
-*/
+// Package cmd provides the top level commands for the application
 package cmd
 
 import (
 	"github.com/spf13/cobra"
 )
 
+// Root is the root command for this program
 var Root = &cobra.Command{
 	Use:   "x40.link",
 	Short: "Links for Skinks",

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -1,12 +1,14 @@
-// package configuration lists all of the appropriate configuration options, sets defaults and so on.
+// Package configuration lists all of the appropriate configuration options, sets defaults and so on.
 package configuration
 
+// Storage* is configuration related to the link storage logic.
 const (
-	// Storage* is configuration related to the link storage logic.
 	StorageYamlFile   = "storage.yaml.file"
 	StorageHashMap    = "storage.hash-map"
 	StorageBoltDBFile = "store.boltdb.file"
+)
 
-	// Server* is configuration that modifies how the server is run
+// Server* is configuration that modifies how the server is run
+const (
 	ServerListenAddress = "server.listen-address"
 )

--- a/storage/boltdb/boltdb.go
+++ b/storage/boltdb/boltdb.go
@@ -1,3 +1,4 @@
+// Package boltdb implements storage based on the BoltDB database, backed by the filesystem.
 package boltdb
 
 import (
@@ -10,6 +11,7 @@ import (
 	"go.etcd.io/bbolt"
 )
 
+// Err* are sentinel errors
 var (
 	ErrFailedToSetupDatabase = errors.New("failed to setup backing database")
 	ErrFailedToTX            = errors.New("failed to complete database transaction")
@@ -49,13 +51,13 @@ func New(path string, opts ...Option) (*BoltDB, error) {
 		}
 	}
 
-	new, err := bbolt.Open(path, 0600, bopts)
+	n, err := bbolt.Open(path, 0600, bopts)
 	if err != nil {
 		return nil, fmt.Errorf("%w: %s", ErrFailedToSetupDatabase, err)
 	}
 
 	return &BoltDB{
-		db: new,
+		db: n,
 	}, nil
 }
 
@@ -69,6 +71,7 @@ func WithFileLockWait(dur time.Duration) Option {
 	}
 }
 
+// Get returns a URL, given another input URL
 func (b *BoltDB) Get(in *url.URL) (*url.URL, error) {
 	var u *url.URL
 
@@ -98,6 +101,7 @@ func (b *BoltDB) Get(in *url.URL) (*url.URL, error) {
 	return u, nil
 }
 
+// Put saves a URL to the datastore
 func (b *BoltDB) Put(f *url.URL, t *url.URL) error {
 	return b.db.Update(func(tx *bbolt.Tx) error {
 		b, err := tx.CreateBucketIfNotExists(txBucketName)

--- a/storage/doc.go
+++ b/storage/doc.go
@@ -1,4 +1,4 @@
-// package storage provides an interface that can be used to connect to various ways
+// Package storage provides an interface that can be used to connect to various ways
 // that links can be stored and retrieved. It also stores common variables and parameters
 // that are expected to be used across the store implementations.
 package storage

--- a/storage/memory/binary_search.go
+++ b/storage/memory/binary_search.go
@@ -18,6 +18,7 @@ type BinarySearch struct {
 	mu  sync.RWMutex
 }
 
+// NewBinarySearch initializes a binary search object with its own properties initialized
 func NewBinarySearch() *BinarySearch {
 	return &BinarySearch{
 		idx: make([]tu, 0),
@@ -63,7 +64,7 @@ func (bs *BinarySearch) find(in *url.URL) (found bool, nearest int) {
 	}
 }
 
-// Fetch the record.
+// Get returns an URL, given an input URL
 func (bs *BinarySearch) Get(in *url.URL) (*url.URL, error) {
 	bs.mu.RLock()
 	defer bs.mu.RUnlock()
@@ -76,7 +77,7 @@ func (bs *BinarySearch) Get(in *url.URL) (*url.URL, error) {
 	return nil, storage.ErrNotFound
 }
 
-// Write the record into the set. Takes responsibility for determining the position in which to add the
+// Put writes the record into the set. Takes responsibility for determining the position in which to add the
 // new value, so that the underlying set retains order.
 func (bs *BinarySearch) Put(f *url.URL, t *url.URL) error {
 	bs.mu.Lock()

--- a/storage/memory/doc.go
+++ b/storage/memory/doc.go
@@ -1,3 +1,3 @@
-// Memory stores the entire data set in memory. There are different "layouts" in memory, in which URLs can be looked
-// up using different algorithms. Each implementation is named after its search algorithm.
+// Package memory stores the entire data set in memory. There are different "layouts" in memory, in which URLs can be
+// looked up using different algorithms. Each implementation is named after its search algorithm.
 package memory

--- a/storage/memory/hash_table.go
+++ b/storage/memory/hash_table.go
@@ -37,7 +37,7 @@ func (ht *HashTable) Get(in *url.URL) (*url.URL, error) {
 	return nil, storage.ErrNotFound
 }
 
-// Storage writes a URL into memory. Designed to be used primarily via "loader" infrastructure, such as the
+// Put writes a URL into memory. Designed to be used primarily via "loader" infrastructure, such as the
 // YAML loader.
 func (ht *HashTable) Put(f *url.URL, t *url.URL) error {
 	ht.mu.Lock()

--- a/storage/memory/linear_search.go
+++ b/storage/memory/linear_search.go
@@ -16,12 +16,14 @@ type LinearSearch struct {
 	mu sync.RWMutex
 }
 
+// NewLinearSearch implements the most naive approach to querying data
 func NewLinearSearch() *LinearSearch {
 	return &LinearSearch{
 		idx: make([]tu, 0),
 	}
 }
 
+// Get queries the linear search. It just iterates through the whole slice.
 func (s *LinearSearch) Get(in *url.URL) (*url.URL, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -35,6 +37,7 @@ func (s *LinearSearch) Get(in *url.URL) (*url.URL, error) {
 	return nil, storage.ErrNotFound
 }
 
+// Put writes the URL into storage, appending it to the slice.
 func (s *LinearSearch) Put(f *url.URL, t *url.URL) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -39,7 +39,11 @@ var teardownFunc = map[string]func(string){
 	"hash table":    func(string) {},
 	"linear search": func(string) {},
 	"binary search": func(string) {},
-	"boltdb":        func(n string) { os.Remove(path.Join(os.TempDir(), "test+"+n+"+url-shortner.db")) },
+	"boltdb": func(n string) {
+		if err := os.Remove(path.Join(os.TempDir(), "test+"+n+"+url-shortner.db")); err != nil {
+			panic(err)
+		}
+	},
 }
 
 // benchmark is a generic approach to benchmarking the various different storage implementations at different underlying data

--- a/storage/test/test.go
+++ b/storage/test/test.go
@@ -1,4 +1,4 @@
-// package test provides a storage implementation designed explicitly for testing
+// Package test provides a storage implementation designed explicitly for testing
 package test
 
 import (
@@ -7,8 +7,8 @@ import (
 	"github.com/andrewhowdencom/x40.link/storage"
 )
 
-// TestOption modifies the behavior of New() in specific ways that make it valuable for the test.
-type TestOption func(t *ts)
+// Option modifies the behavior of New() in specific ways that make it valuable for the test.
+type Option func(t *ts)
 
 // ts is test storage
 type ts struct {
@@ -19,7 +19,7 @@ type ts struct {
 }
 
 // New generates the test storage implementation
-func New(opts ...TestOption) *ts {
+func New(opts ...Option) *ts {
 	n := &ts{}
 
 	for _, o := range opts {
@@ -31,7 +31,7 @@ func New(opts ...TestOption) *ts {
 
 // WithError modifies the storage implementation such that any operation executed against it will return
 // an error.
-func WithError(err error) TestOption {
+func WithError(err error) Option {
 	return func(t *ts) {
 		t.err = err
 	}

--- a/storage/yaml/doc.go
+++ b/storage/yaml/doc.go
@@ -1,4 +1,4 @@
-// package yaml provides a read only storage implementation which sources its URLs from a YAML file. THe file is
+// Package yaml provides a read only storage implementation which sources its URLs from a YAML file. THe file is
 // expected to be in the format:
 //
 //	---

--- a/storage/yaml/yaml.go
+++ b/storage/yaml/yaml.go
@@ -10,9 +10,9 @@ import (
 	parser "gopkg.in/yaml.v3"
 )
 
-// The logger for the library. Uses the default structured logger, but can be overridden to disable the output
+// Log is the logger for the library. Uses the default structured logger, but can be overridden to disable the output
 // for this package.
-var Log *slog.Logger = slog.Default()
+var Log = slog.Default()
 
 // Yaml is a simple, read only implement of storage that fetches its initial state from a file and then returns
 // that state. It rejects any writes.
@@ -32,7 +32,7 @@ type row struct {
 // New generates the storer. It receives another storer which it will enrich with the content from the YAML,
 // and an io.reader which is expected to supply the YAML (typically a file).
 //
-// Returns an error in the case there is a failure to store the URL or to whollely fail the YAML parsing, but
+// Returns an error in the case there is a failure to store the URL or to wholely fail the YAML parsing, but
 // ignores single line failures (simply skipping the record)
 func New(str storage.Storer, src io.Reader) (*yaml, error) {
 	y := &yaml{str: str}


### PR DESCRIPTION
This commit makes the code a little stricter through the 'revive'
linter. The work was sponsored by make-server branch, which had a 'TODO'
to ensure all code was 'sufficiently documented'. Rather than try and
figure that out as a human, it is simpler to enable a linter.

However, with the linter enabled, the codebase needs to be reconciled
against it. Given this, this commit also does that.
