### PR TITLE
Add protobuf tools to build environment

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -40,8 +40,8 @@ jobs:
       run: task tools/go/install
 
     # Validation
-    - name: Build Binaries (check the syntax)
-      run: task bin/all
+    - name: Try the build process
+      run: task bin/all container/build
 
     # Test
     - name: Test

--- a/Containerfile
+++ b/Containerfile
@@ -22,7 +22,7 @@ WORKDIR /mnt
 COPY . /mnt
 
 # Build the binary
-RUN task bin
+RUN task tools/go/install bin
 
 # An imagine with SSL certificates (and some other Linux niceties)
 # See


### PR DESCRIPTION
In previous work (2115076), protobuf was added as a critical dependency
of this project. Unfortunately, the tools required to install it were
not included.

This commit reconciles that delta.

== Design Notes
=== Container in PR

This commit also builds the container within the pull request, as this
would have caught the previous bug.
