### PR TITLE
Fix path matching

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -74,7 +74,7 @@ func WithStorage(str storage.Storer) Option {
 			str: str,
 		}
 
-		mux.Get("/{slug}", sh.Redirect)
+		mux.NotFound(sh.Redirect)
 
 		return nil
 	}

--- a/storage/firestore/firestore.go
+++ b/storage/firestore/firestore.go
@@ -78,8 +78,7 @@ func (fs Firestore) Put(from *url.URL, to *url.URL) error {
 // urlToPath converts the URL into a document ID.
 func urlToPath(url *url.URL) string {
 	return path.Join(
-		FirestoreCollection,
-		url.Host,
-		strings.Replace(url.Path, "/", "+", -1),
+		FirestoreCollection, url.Host,
+		"id", strings.Replace(url.Path, "/", "+", -1),
 	)
 }


### PR DESCRIPTION
After the shift to firebase, even with valid records in the database there is no redirects taking place. The reason is (apparently) twofold:

1. Firebase appears to need its IDs to be in key/value pairs, despite them *looking* like a path. Fine, but it means they must always be an even number of pairs.
2. The attempted redirect is for the root domain ("/") which is not matching the slug.

This commit seeks to address both those minor issues.