### PR TITLE
Fix h2c handler issues

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -74,7 +74,7 @@ func WithStorage(str storage.Storer) Option {
 			str: str,
 		}
 
-		mux.NotFound(sh.Redirect)
+		mux.Get("/*", sh.Redirect)
 
 		return nil
 	}


### PR DESCRIPTION
In one of the more bizarre bugs, whenever HTTP H2C is used, the noroute
implementation does not work. This commit fixes that by using a
wildcard, not a noroute.
