### PR TITLE
Refactor away the handler implementations in interceptor

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -18,7 +18,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
-	"golang.org/x/net/http2"
 )
 
 const (
@@ -121,7 +120,7 @@ func RunServe(cmd *cobra.Command, _ []string) error {
 	}
 
 	if viper.GetBool(configuration.ServerH2CEnabled) {
-		args = append(args, server.WithH2C(&http2.Server{}))
+		args = append(args, server.WithH2C())
 	}
 
 	if viper.GetBool(configuration.ServerGRPCAPIEnabled) {

--- a/server/interceptor.go
+++ b/server/interceptor.go
@@ -1,76 +1,25 @@
 package server
 
 import (
-	"bufio"
-	"errors"
-	"fmt"
-	"io"
-	"net"
 	"net/http"
 
 	"github.com/andrewhowdencom/x40.link/server/message"
-	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
-	"golang.org/x/net/http2"
-	"google.golang.org/grpc"
 )
 
-// bufConn wraps a net.Conn, but reads drain the bufio.Reader first.
-type bufConn struct {
-	net.Conn
-	*bufio.Reader
-}
-
-func (c *bufConn) Read(p []byte) (int, error) {
-	if c.Reader == nil {
-		return c.Conn.Read(p)
-	}
-	n := c.Reader.Buffered()
-	if n == 0 {
-		c.Reader = nil
-		return c.Conn.Read(p)
-	}
-	if n < len(p) {
-		p = p[:n]
-	}
-	return c.Reader.Read(p)
-}
-
-// Err* are sentinel errors
-var (
-	ErrUnableToHijackConnection = errors.New("unable to hijack connection")
-	ErrReadingClientPreface     = errors.New("error reading h2c client preface")
-)
-
-// Interceptor is a superset type of HTTP Handler that includes matching logic.
-type Interceptor interface {
-	http.Handler
-
-	Match(r *http.Request) bool
-}
-
-// GRPCGateway offloads requests destined to the GRPCGateway to the embedded handler
-type GRPCGateway struct {
-	*runtime.ServeMux
-}
-
-// Match indicates that a request should be intercepted and sent to the gRPC Gateway
-func (gw GRPCGateway) Match(r *http.Request) bool {
+// IsExpectingJSON indicates that a request is looking to expect JSON. In practice, this is used to redirect
+// to the gRPC API
+func IsExpectingJSON(r *http.Request) bool {
 	// There is nothing else on this server that is expecting a JSON response. Given this, forward everything
 	// JSON related to the handler.
 	return r.Header.Get(message.HeaderAccept) == message.MIMEApplicationJSON
 }
 
-// GRPC offloads requests destined for GRPC directly.
-type GRPC struct {
-	*grpc.Server
-}
-
-// Match offloads requests to the gRPC mux. Note: This does not use a bunch of GRPC features; that's fine.
+// IsGRPC offloads requests to the gRPC mux. Note: This does not use a bunch of GRPC features; that's fine.
 //
 // See
 // - https://github.com/philips/grpc-gateway-example/blob/master/cmd/serve.go#L51-L61
 // - https://ahmet.im/blog/grpc-http-mux-go/
-func (g GRPC) Match(r *http.Request) bool {
+func IsGRPC(r *http.Request) bool {
 
 	// GRPC has its own mime type.
 	if r.Header.Get(message.HeaderContentType) != message.MIMEGRPC {
@@ -85,17 +34,7 @@ func (g GRPC) Match(r *http.Request) bool {
 	return true
 }
 
-// H2C introspects the request and, if it appears to be a HTTP request with prior knowledge, passes it to the HTTP/2
-// handler. Only a partial re-implementation of H2C middleware, as the Upgrade path was deprecated in RFC9113
-//
-// See
-// 1. https://pkg.go.dev/golang.org/x/net/http2/h2c
-// 2. https://github.com/golang/go/discussions/60746
-type H2C struct {
-	*http2.Server
-}
-
-// Match does the detection of the initial message. The message looks like:
+// IsH2C does the detection of the initial message. The message looks like:
 //
 //	PRI * HTTP/2.0
 //
@@ -106,7 +45,7 @@ type H2C struct {
 //
 // (At least, as reproduced by $ curl --http2-prior-knowledge). See:
 // 1. https://www.rfc-editor.org/rfc/rfc7540#section-4.1
-func (h2c H2C) Match(r *http.Request) bool {
+func IsH2C(r *http.Request) bool {
 	if r.Method != "PRI" {
 		return false
 	}
@@ -126,69 +65,15 @@ func (h2c H2C) Match(r *http.Request) bool {
 	return true
 }
 
-// ServeHTTP initializes the HTTP/2 connection.
-// See http2/h2c:initH2CWithPriorKnowledge for details.
-func (h2c H2C) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	hijacker, ok := w.(http.Hijacker)
-
-	if !ok {
-		WithError(req, fmt.Errorf("%w: %s", ErrUnableToHijackConnection, "does not meet hijacker interface"))
-		return
-	}
-
-	conn, rw, err := hijacker.Hijack()
-	if err != nil {
-		WithError(req, fmt.Errorf("%w: %s", ErrUnableToHijackConnection, err.Error()))
-		return
-	}
-
-	// Read the prior knowledge message into a buffer, and validate it.
-	expected := "SM\r\n\r\n"
-	buf := make([]byte, len(expected))
-	n, err := io.ReadFull(rw, buf)
-
-	if err != nil {
-		WithError(req, fmt.Errorf("%w: %s", ErrReadingClientPreface, err))
-		return
-	}
-
-	// If the message does not match the "indicate upgrade", cancel the connection.
-	if string(buf[:n]) != expected {
-		WithError(req, fmt.Errorf("%w: %s", ErrReadingClientPreface, "preface message not correct"))
-
-		// The error is ignored as we are already in an error handler.
-		_ = conn.Close()
-		return
-	}
-
-	// We do not mind whether the flush works.
-	_ = rw.Flush()
-	if rw.Reader.Buffered() != 0 {
-		conn = &bufConn{conn, rw.Reader}
-	}
-
-	defer conn.Close() //nolint:errcheck
-
-	// Fetch initial server out of the existing request, and use it as base configuration to serve the same request
-	// over HTTP/2
-	srv := req.Context().Value(http.ServerContextKey).(*http.Server)
-	h2c.ServeConn(conn, &http2.ServeConnOpts{
-		Context:          req.Context(),
-		BaseConfig:       srv,
-		Handler:          srv.Handler,
-		SawClientPreface: true,
-	})
-}
-
 // Intercept is a type of middleware that offloads messages that are destined for the "default" handler and instead
 // redirects them to some other handler.
 //
 // This allows using more complex matching logic. See IsGRPCGateway for an example.
-func Intercept(interceptor Interceptor) func(next http.Handler) http.Handler {
+func Intercept(matches func(req *http.Request) bool, intercept http.Handler) func(next http.Handler) http.Handler {
 	return func(standard http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if interceptor.Match(r) {
-				interceptor.ServeHTTP(w, r)
+			if matches(r) {
+				intercept.ServeHTTP(w, r)
 				return
 			}
 

--- a/server/interceptor_test.go
+++ b/server/interceptor_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestGRPCGateway_Match(t *testing.T) {
+func TestIsExpectingJSON(t *testing.T) {
 	t.Parallel()
 
 	for _, tc := range []struct {
@@ -53,14 +53,12 @@ func TestGRPCGateway_Match(t *testing.T) {
 				}
 			}
 
-			gw := &server.GRPCGateway{}
-
-			assert.Equal(t, tc.expected, gw.Match(req))
+			assert.Equal(t, tc.expected, server.IsExpectingJSON(req))
 		})
 	}
 }
 
-func TestGRPC_Match(t *testing.T) {
+func TestIsGRPC(t *testing.T) {
 	t.Parallel()
 
 	nr := func(hk, hv string, ver int) *http.Request {
@@ -101,9 +99,7 @@ func TestGRPC_Match(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			gr := server.GRPC{}
-
-			assert.Equal(t, tc.expected, gr.Match(tc.req))
+			assert.Equal(t, tc.expected, server.IsGRPC(tc.req))
 		})
 	}
 }
@@ -169,8 +165,7 @@ func TestH2C_Match(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			h2c := server.H2C{}
-			assert.Equal(t, tc.expected, h2c.Match(tc.req))
+			assert.Equal(t, tc.expected, server.IsH2C(tc.req))
 		})
 	}
 }


### PR DESCRIPTION
Currently there is a conceptual problem I'm trying to figure out: How to
limit the handler(s) to respond only on specific "virtual hosts" (or
when the host header matches a request), instead of responding on all.
The XY problem I'm looking to solve is how to:

1. Shift the API queries to go behind an API endpoint (api.x40.link), so
   that x40.link can be safely "heavily cached" (either indefinitely
   with invalidation, or for 5 minutes or so without it).
2. Allow a UI to be embedded at app.x40.link

This would allow x40.link to be sent back to the app, and the API
configured never to be cached.

To do that, we need to extend the Match() function so "matchers can wrap
matchers". So, a virtual host allowlist can happen before other
matchers, thereby allowing us to limit the requests arbitrarily.

== Design Notes
=== H2C

The largest change that happens in this pull request is removing H2C.
This is possible because the only part of H2C we actually need is the
matching part, rather than the rest.
