### PR TITLE
Limit API access to specific hosts

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -57,4 +57,4 @@ ENV GOOS="linux"
 
 COPY --from=build /mnt/dist/linux+${GOARCH}/x40.link /usr/bin/x40.link
 
-CMD ["/usr/bin/x40.link", "serve", "--with-boltdb", "/tmp/urls.db", "--listen-address", "0.0.0.0:80"]
+CMD ["/usr/bin/x40.link", "serve", "--storage.boltdb.file", "/tmp/urls.db", "--server.listen-address", "0.0.0.0:80"]

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/andrewhowdencom/x40.link/configuration"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -23,18 +24,18 @@ func TestGetStorage(t *testing.T) {
 	}{
 		{
 			name:  "in memory storage",
-			fName: flagStrHashMap,
+			fName: configuration.StorageHashMap,
 			fVal:  "true",
 		},
 		{
 			name:  "disabled in memory storage",
-			fName: flagStrHashMap,
+			fName: configuration.StorageHashMap,
 			fVal:  "false",
 			err:   ErrFailedStorageSetup,
 		},
 		{
 			name:  "yaml storage",
-			fName: flagStrYAML,
+			fName: configuration.StorageYamlFile,
 			fVal:  tmpDir + "/urls.yaml",
 			setup: func() {
 				file, err := os.Create(tmpDir + "/urls.yaml")

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -3,9 +3,9 @@ package configuration
 
 // Server* is configuration that modifies how the server is run
 const (
-	ServerListenAddress  = "server.listen-address"
-	ServerHTTPAPIEnabled = "server.api.http.enabled"
-	ServerGRPCAPIEnabled = "server.api.grpc.enabled"
+	ServerListenAddress = "server.listen-address"
+	ServerAPIHTTPHost   = "server.api.http.host"
+	ServerAPIGRPCHost   = "server.api.grpc.host"
 
 	ServerH2CEnabled = "server.protocol.h2c.enabled"
 )
@@ -14,6 +14,6 @@ const (
 const (
 	StorageYamlFile         = "storage.yaml.file"
 	StorageHashMap          = "storage.hash-map"
-	StorageBoltDBFile       = "store.boltdb.file"
+	StorageBoltDBFile       = "storage.boltdb.file"
 	StorageFirestoreProject = "storage.firestore.project"
 )

--- a/deploy/prod/cr/service.yaml
+++ b/deploy/prod/cr/service.yaml
@@ -22,8 +22,10 @@ spec:
           command: ["/usr/bin/x40.link"]
           args: 
             - "serve"
-            - "--listen-address=0.0.0.0:8080"
-            - "--with-firestore=andrewhowdencom"
+            - "--server.listen-address=0.0.0.0:8080"
+            - "--storage.firestore.project=andrewhowdencom"
+            - "--server.api.grpc=api.x40.link"
+            - "--server.api.http"
           ports:
           # Naming the port H2C gives a hint to Google Clouds load balancing infrastructure that this application
           # supports HTTP/2 without TLS.

--- a/server/server.go
+++ b/server/server.go
@@ -83,11 +83,14 @@ func WithStorage(str storage.Storer) Option {
 
 // WithGRPCGateway configures an interceptor to offload requests to the GRPC Gateway mux. Must be used before
 // any option that creates a route (e.g. WithStorage)
-func WithGRPCGateway() Option {
+func WithGRPCGateway(limits ...MatcherFunc) Option {
 	return func(srv *http.Server) error {
 		mux := srv.Handler.(*chi.Mux)
 
-		mux.Use(Intercept(IsExpectingJSON, api.NewGRPCGatewayMux()))
+		mux.Use(Intercept(
+			AllOf(append(limits, IsExpectingJSON)...),
+			api.NewGRPCGatewayMux()),
+		)
 
 		return nil
 	}
@@ -110,10 +113,14 @@ func WithH2C() Option {
 }
 
 // WithGRPC enables GRPC to be served over the
-func WithGRPC() Option {
+func WithGRPC(limits ...MatcherFunc) Option {
 	return func(srv *http.Server) error {
 		mux := srv.Handler.(*chi.Mux)
-		mux.Use(Intercept(IsGRPC, api.NewGRPCMux()))
+
+		mux.Use(Intercept(
+			AllOf(append(limits, IsGRPC)...),
+			api.NewGRPCMux()),
+		)
 
 		return nil
 	}


### PR DESCRIPTION
As mentioned in 307eab3, the goal generally is to have the API be behind
api.x40.link. This commit makes that possible by building a new
filtering mechanism to wrap the existing matchers (IsHost) and a new
method to combine matchers (AllOf).

== Design Notes
=== Refactoring Flags

This commit makes an enormous breaking change to the UI — all of the
flags are changed. The reason for this is the new flag design is
simpler, both in terms of the implementation (using the configuration
paths as flags) and in terms of the reasonability (all configuration
flags can be inspected via the CLI).
