### PR TITLE
Enable the gRPC reflection API

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -8,6 +8,7 @@ import (
 	"github.com/andrewhowdencom/x40.link/api/gen/dev"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/reflection"
 )
 
 // NewGRPCGatewayMux provides a mux with all GRPC Gateway routes configured.
@@ -28,6 +29,8 @@ func NewGRPCMux() *grpc.Server {
 	m := grpc.NewServer()
 
 	dev.RegisterManageURLsServer(m, &dev.UnimplementedManageURLsServer{})
+
+	reflection.Register(m)
 
 	return m
 }


### PR DESCRIPTION
GRPC allows discovering the different API endpoints to work with via a
"reflection API":

1. https://github.com/fullstorydev/grpcurl
2. https://github.com/grpc/grpc/blob/master/src/proto/grpc/reflection/v1/reflection.proto
3. https://github.com/grpc/grpc-go/blob/master/Documentation/server-reflection-tutorial.md
4. https://github.com/grpc/grpc-go/tree/master/reflection

This allows the tool grpcurl to natively interact with the application.
If the tool proves easy to use, it additionally removes a substantial
reason for the gRPC+JSON Gateway (which was ease of use when
prototyping)
