### PR TITLE
Correct the startup flags

### DIFF
--- a/deploy/prod/cr/service.yaml
+++ b/deploy/prod/cr/service.yaml
@@ -24,8 +24,8 @@ spec:
             - "serve"
             - "--server.listen-address=0.0.0.0:8080"
             - "--storage.firestore.project=andrewhowdencom"
-            - "--server.api.grpc=api.x40.link"
-            - "--server.api.http"
+            - "--server.api.grpc.host=api.x40.link"
+            - "--server.api.http.host=api.x40.link"
           ports:
           # Naming the port H2C gives a hint to Google Clouds load balancing infrastructure that this application
           # supports HTTP/2 without TLS.


### PR DESCRIPTION
Currently the application releases do not boot as the flags to start
them are incorrect.

This commit addresses that.
