### PR TITLE
Adjust the interfaces for the GRPC and GPRCGateway calls

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -25,8 +25,8 @@ func NewGRPCGatewayMux() *runtime.ServeMux {
 }
 
 // NewGRPCMux generates a valid GRPC server with all GRPC routes configured.
-func NewGRPCMux() *grpc.Server {
-	m := grpc.NewServer()
+func NewGRPCMux(opts ...grpc.ServerOption) *grpc.Server {
+	m := grpc.NewServer(opts...)
 
 	dev.RegisterManageURLsServer(m, &dev.UnimplementedManageURLsServer{})
 

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -95,16 +95,12 @@ func RunServe(cmd *cobra.Command, _ []string) error {
 		viper.GetString(configuration.ServerAPIHTTPHost),
 		viper.GetString(configuration.ServerAPIGRPCHost)
 
-	if jHost == "*" {
-		args = append(args, server.WithGRPCGateway())
-	} else if jHost != "" {
-		args = append(args, server.WithGRPCGateway(server.IsHost(jHost)))
+	if jHost != "" || cmd.Flags().Lookup(configuration.ServerAPIHTTPHost).Changed {
+		args = append(args, server.WithGRPCGateway(jHost, nil))
 	}
 
-	if gHost == "*" {
-		args = append(args, server.WithGRPC())
-	} else if gHost != "" {
-		args = append(args, server.WithGRPC(server.IsHost(gHost)))
+	if gHost != "" || cmd.Flags().Lookup(configuration.ServerAPIGRPCHost).Changed {
+		args = append(args, server.WithGRPC(gHost))
 	}
 
 	args = append(args,

--- a/server/server.go
+++ b/server/server.go
@@ -83,14 +83,26 @@ func WithStorage(str storage.Storer) Option {
 
 // WithGRPCGateway configures an interceptor to offload requests to the GRPC Gateway mux. Must be used before
 // any option that creates a route (e.g. WithStorage)
-func WithGRPCGateway(limits ...MatcherFunc) Option {
+func WithGRPCGateway(host string, middleware func(http.Handler) http.Handler) Option {
 	return func(srv *http.Server) error {
-		mux := srv.Handler.(*chi.Mux)
+		var handler http.Handler = api.NewGRPCGatewayMux()
 
-		mux.Use(Intercept(
-			AllOf(append(limits, IsExpectingJSON)...),
-			api.NewGRPCGatewayMux()),
-		)
+		mux := srv.Handler.(*chi.Mux)
+		filters := []MatcherFunc{
+			IsExpectingJSON,
+		}
+
+		// Allow the GRPC Gateway to filter to specific hosts, if required.
+		if host != "" {
+			filters = append(filters, IsHost(host))
+		}
+
+		// Allow the gRPC Gateway to have additional middleware (e.g. auth), if required.
+		if middleware != nil {
+			handler = middleware(handler)
+		}
+
+		mux.Use(Intercept(AllOf(filters...), handler))
 
 		return nil
 	}
@@ -113,14 +125,19 @@ func WithH2C() Option {
 }
 
 // WithGRPC enables GRPC to be served over the
-func WithGRPC(limits ...MatcherFunc) Option {
+func WithGRPC(host string) Option {
 	return func(srv *http.Server) error {
 		mux := srv.Handler.(*chi.Mux)
+		filters := []MatcherFunc{
+			IsGRPC,
+		}
 
-		mux.Use(Intercept(
-			AllOf(append(limits, IsGRPC)...),
-			api.NewGRPCMux()),
-		)
+		// Allow the GRPC Gateway to filter to specific hosts, if required.
+		if host != "" {
+			filters = append(filters, IsHost(host))
+		}
+
+		mux.Use(Intercept(AllOf(filters...), api.NewGRPCMux()))
 
 		return nil
 	}


### PR DESCRIPTION
In parallel, there's quite a lot of work to try and figure out how to
authenticate the API. Future work will expand on this further, but the
TLDR is that both the gRPC interface and the GRPC+Gateway interface will
need to be separately authenticated, as while they're both invoked via
HTTP, they reach the (gRPC) Server implementation via different paths —
there's no common middleground sufficiently informed to make a decision.

This commit allows supplying that middleground in context specific ways
— via HTTP middleware for the gateway, and via interceptors for gRPC
