### PR TITLE
Remove the gRPC Gateway implementation

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -188,7 +188,5 @@ tasks:
     desc: "Installs a series of go tools"
     cmds:
       - go install "github.com/bufbuild/buf/cmd/buf"
-      - go install "github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-grpc-gateway"
-      - go install "github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2"
       - go install "google.golang.org/grpc/cmd/protoc-gen-go-grpc"
       - go install "google.golang.org/protobuf/cmd/protoc-gen-go"

--- a/api/api.go
+++ b/api/api.go
@@ -3,26 +3,10 @@
 package api
 
 import (
-	"context"
-
 	"github.com/andrewhowdencom/x40.link/api/gen/dev"
-	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/reflection"
 )
-
-// NewGRPCGatewayMux provides a mux with all GRPC Gateway routes configured.
-func NewGRPCGatewayMux() *runtime.ServeMux {
-
-	m := runtime.NewServeMux()
-
-	// Register the gateway routes
-	if err := dev.RegisterManageURLsHandlerServer(context.Background(), m, &dev.UnimplementedManageURLsServer{}); err != nil {
-		panic(err)
-	}
-
-	return m
-}
 
 // NewGRPCMux generates a valid GRPC server with all GRPC routes configured.
 func NewGRPCMux(opts ...grpc.ServerOption) *grpc.Server {

--- a/api/buf.gen.yaml
+++ b/api/buf.gen.yaml
@@ -8,12 +8,3 @@ plugins:
     out: gen
     opt:
       - paths=source_relative
-  - plugin: grpc-gateway
-    out: gen
-    opt:
-      - paths=source_relative
-  - plugin: openapiv2
-    out: openapi
-    strategy: all
-    opt: allow_merge=true,merge_file_name=api
-

--- a/api/dev/url.proto
+++ b/api/dev/url.proto
@@ -23,24 +23,11 @@ message PutRequest {
 
 service ManageURLs {
     // Get queries a URL, returning the URL if there was found (or none, if it was not found)
-    rpc Get(Request) returns (Response) {
-        option (google.api.http) = {
-            get: "/dev/url"
-        };
-    }
+    rpc Get(Request) returns (Response) {}
 
     // Post generates a new URL with a generated suffix.
-    rpc Post(Request) returns (Response) {
-        option (google.api.http) = {
-            post: "/dev/url"
-            body: "*"
-        };
-    }
+    rpc Post(Request) returns (Response) {}
 
-    rpc Put(PutRequest) returns (google.protobuf.Empty) {
-        option (google.api.http) = {
-            put: "/dev/url"
-            body: "*"
-        };
-    }
+    // Put writes a new URL to the store
+    rpc Put(PutRequest) returns (google.protobuf.Empty) {}
 }

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -62,8 +62,7 @@ func init() {
 	serveFlagSet.StringP(configuration.StorageFirestoreProject, "f", "", "Use the firestore database at project <input>")
 
 	// API configuration
-	serveFlagSet.StringP(configuration.ServerAPIGRPCHost, "g", "", "The host on which to listen for GRPC requests (* for all)")
-	serveFlagSet.StringP(configuration.ServerAPIHTTPHost, "j", "", "The host on which to listen to HTTP+JSON requests (* for all)")
+	serveFlagSet.StringP(configuration.ServerAPIGRPCHost, "g", "", "The host on which to listen for GRPC requests")
 
 	// Protocol configuration
 	serveFlagSet.BoolP(configuration.ServerH2CEnabled, "c", true, "Whether to enable HTTP/2 cleartext (with prior knowledge)")
@@ -91,16 +90,10 @@ func RunServe(cmd *cobra.Command, _ []string) error {
 		args = append(args, server.WithH2C())
 	}
 
-	jHost, gHost :=
-		viper.GetString(configuration.ServerAPIHTTPHost),
-		viper.GetString(configuration.ServerAPIGRPCHost)
+	apiHost := viper.GetString(configuration.ServerAPIGRPCHost)
 
-	if jHost != "" || cmd.Flags().Lookup(configuration.ServerAPIHTTPHost).Changed {
-		args = append(args, server.WithGRPCGateway(jHost, nil))
-	}
-
-	if gHost != "" || cmd.Flags().Lookup(configuration.ServerAPIGRPCHost).Changed {
-		args = append(args, server.WithGRPC(gHost))
+	if apiHost != "" || cmd.Flags().Lookup(configuration.ServerAPIGRPCHost).Changed {
+		args = append(args, server.WithGRPC(apiHost))
 	}
 
 	args = append(args,

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -4,7 +4,6 @@ package configuration
 // Server* is configuration that modifies how the server is run
 const (
 	ServerListenAddress = "server.listen-address"
-	ServerAPIHTTPHost   = "server.api.http.host"
 	ServerAPIGRPCHost   = "server.api.grpc.host"
 
 	ServerH2CEnabled = "server.protocol.h2c.enabled"

--- a/deploy/prod/cr/service.yaml
+++ b/deploy/prod/cr/service.yaml
@@ -25,7 +25,6 @@ spec:
             - "--server.listen-address=0.0.0.0:8080"
             - "--storage.firestore.project=andrewhowdencom"
             - "--server.api.grpc.host=api.x40.link"
-            - "--server.api.http.host=api.x40.link"
           ports:
           # Naming the port H2C gives a hint to Google Clouds load balancing infrastructure that this application
           # supports HTTP/2 without TLS.

--- a/docs/content/reference/api/openapi.md
+++ b/docs/content/reference/api/openapi.md
@@ -1,3 +1,0 @@
-# OpenAPI
-
-<swagger-ui src="/static/api/api.json"/>

--- a/go.mod
+++ b/go.mod
@@ -7,14 +7,12 @@ require (
 	github.com/andrewhowdencom/sysexits v0.0.0-20230825110138-f9dd56ec6fce
 	github.com/bufbuild/buf v1.28.1
 	github.com/go-chi/chi/v5 v5.0.11
-	github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.0
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.18.2
 	github.com/stretchr/testify v1.8.4
 	go.etcd.io/bbolt v1.3.8
 	golang.org/x/net v0.19.0
-	google.golang.org/api v0.153.0
 	google.golang.org/genproto/googleapis/api v0.0.0-20240108191215-35c7eff3a6b1
 	google.golang.org/grpc v1.60.1
 	google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.3.0
@@ -108,6 +106,7 @@ require (
 	golang.org/x/text v0.14.0 // indirect
 	golang.org/x/time v0.5.0 // indirect
 	golang.org/x/tools v0.15.0 // indirect
+	google.golang.org/api v0.153.0 // indirect
 	google.golang.org/appengine v1.6.8 // indirect
 	google.golang.org/genproto v0.0.0-20240102182953-50ed04b92917 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240102182953-50ed04b92917 // indirect

--- a/go.sum
+++ b/go.sum
@@ -129,8 +129,6 @@ github.com/googleapis/enterprise-certificate-proxy v0.3.2 h1:Vie5ybvEvT75RniqhfF
 github.com/googleapis/enterprise-certificate-proxy v0.3.2/go.mod h1:VLSiSSBs/ksPL8kq3OBOQ6WRI2QnaFynd1DCjZ62+V0=
 github.com/googleapis/gax-go/v2 v2.12.0 h1:A+gCJKdRfqXkr+BIRGtZLibNXf0m1f9E4HG56etFpas=
 github.com/googleapis/gax-go/v2 v2.12.0/go.mod h1:y+aIqrI5eb1YGMVJfuV3185Ts/D7qKpsEkdD5+I6QGU=
-github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.0 h1:Wqo399gCIufwto+VfwCSvsnfGpF/w5E9CNxSwbpD6No=
-github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.0/go.mod h1:qmOFXW2epJhM0qSnUUYpldc7gVz2KMQwJ/QYCDIa7XU=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/ianlancetaylor/demangle v0.0.0-20210905161508-09a460cdf81d/go.mod h1:aYm2/VgdVmcIU8iMfdMvDMsRAQjcfZSKFby6HOFvi/w=

--- a/server/interceptor.go
+++ b/server/interceptor.go
@@ -29,14 +29,6 @@ func IsHost(host string) MatcherFunc {
 	}
 }
 
-// IsExpectingJSON indicates that a request is looking to expect JSON. In practice, this is used to redirect
-// to the gRPC API
-func IsExpectingJSON(r *http.Request) bool {
-	// There is nothing else on this server that is expecting a JSON response. Given this, forward everything
-	// JSON related to the handler.
-	return r.Header.Get(message.HeaderAccept) == message.MIMEApplicationJSON
-}
-
 // IsGRPC offloads requests to the gRPC mux. Note: This does not use a bunch of GRPC features; that's fine.
 //
 // See

--- a/server/interceptor_test.go
+++ b/server/interceptor_test.go
@@ -9,55 +9,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestIsExpectingJSON(t *testing.T) {
-	t.Parallel()
-
-	for _, tc := range []struct {
-		name string
-
-		headers http.Header
-
-		expected bool
-	}{
-		{
-			name: "application/json",
-			headers: http.Header{
-				"accept": {
-					"application/json",
-				},
-			},
-			expected: true,
-		},
-		{
-			name: "text/html",
-			headers: http.Header{
-				"accept": {
-					"text/json",
-				},
-			},
-			expected: false,
-		},
-		{
-			name:     "nothing",
-			expected: false,
-		},
-	} {
-		tc := tc
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
-			req, _ := http.NewRequest("GET", "/", nil)
-			for k, s := range tc.headers {
-				for _, v := range s {
-					req.Header.Add(k, v)
-				}
-			}
-
-			assert.Equal(t, tc.expected, server.IsExpectingJSON(req))
-		})
-	}
-}
-
 func TestIsGRPC(t *testing.T) {
 	t.Parallel()
 

--- a/server/server.go
+++ b/server/server.go
@@ -81,33 +81,6 @@ func WithStorage(str storage.Storer) Option {
 	}
 }
 
-// WithGRPCGateway configures an interceptor to offload requests to the GRPC Gateway mux. Must be used before
-// any option that creates a route (e.g. WithStorage)
-func WithGRPCGateway(host string, middleware func(http.Handler) http.Handler) Option {
-	return func(srv *http.Server) error {
-		var handler http.Handler = api.NewGRPCGatewayMux()
-
-		mux := srv.Handler.(*chi.Mux)
-		filters := []MatcherFunc{
-			IsExpectingJSON,
-		}
-
-		// Allow the GRPC Gateway to filter to specific hosts, if required.
-		if host != "" {
-			filters = append(filters, IsHost(host))
-		}
-
-		// Allow the gRPC Gateway to have additional middleware (e.g. auth), if required.
-		if middleware != nil {
-			handler = middleware(handler)
-		}
-
-		mux.Use(Intercept(AllOf(filters...), handler))
-
-		return nil
-	}
-}
-
 // WithH2C allows piping the connection to a HTTP/2 server, which will hijack the request to use the HTTP/2 protocol
 // but over the initially supplied connection.
 func WithH2C() Option {

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -4,8 +4,6 @@ package tools
 
 import (
 	_ "github.com/bufbuild/buf/cmd/buf"
-	_ "github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-grpc-gateway"
-	_ "github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2"
 	_ "google.golang.org/grpc/cmd/protoc-gen-go-grpc"
 	_ "google.golang.org/protobuf/cmd/protoc-gen-go"
 )


### PR DESCRIPTION
Currently, I'm trying to figure out a nice way to authenticate requests.
This turns out to be challenging with the existing gRPC design —
specifically, the gateway.

The way the gateway is implemented is that it deserializes requests from
JSON into something that the gRPC server implementation expects
(skipping the intermediary layer with proto, as well as a bunch of
other gRPC stuff). This is a reasonable approach, but one of the things
it skips is gRPC interceptors.

In parallel, authentication (as well as debugging and a series of other
use cases) are implemented in GRPC Interceptors. This means that:

1. Authentication would need to be implemented in *both* the gRPC
   gateway design, and the gRPC design
2. The gRPC Gateway would need to be modified to include the
   interceptors (such as proxying all connections over localhost or to a
   buffered connection pool)

Neither seems like the appropriate implementation right now. In
principle, the gRPC gateway could be modified to run the gRPC
interceptors — but it seems this is itself not trivial, as they skip the
intermediary construction of the request.

Given this, this commit opts to avoid the whole problem by ripping out
the gRPC gateway for the time being. There will likely be an answer
here, but rather than pause to figure it out now, the gateway is being
removed.

== Design Notes
=== Harder non-cloud mode

This commit makes the proposed API substantially harder to work in
non-cloud mode, or for developers to poke with tools like cURL. This is
*already* hard for the existing deployment which assumes clients will
handle (in future) OIDC, but for the offline case (e.g. localhost) is
now harder.

Future work will allay these first by building a client that is
especially designed for this, and in the intermediary, people who are
playing can use tools like grpcurl.

=== Potential future avenue

Google Cloud offers something like this via the Cloud Endpoints product:

* https://cloud.google.com/endpoints/docs/grpc/transcoding

But this _essentially_ the same design as proxying it over localhost,
with the exception it "feels better" as "google takes care of" one side
of the connection.
