### PR TITLE
Implement authentication

### DIFF
--- a/api/auth/auth.go
+++ b/api/auth/auth.go
@@ -1,0 +1,105 @@
+// Package auth provides authentication implementation(s) that can be used to limit access to the (gRPC) server.
+package auth
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/coreos/go-oidc/v3/oidc"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+)
+
+// Meta* are the keys to metadata.
+//
+// See https://godoc.org/google.golang.org/grpc/metadata#New
+const (
+	MetaKeyAuthorization = "authorization"
+)
+
+// Err* are sentinel errors
+var (
+	ErrMissingMetadata        = status.Error(codes.InvalidArgument, "missing metadata")
+	ErrMissingAuthorization   = status.Error(codes.InvalidArgument, "missing authorization")
+	ErrCorruptedAuthorization = status.Error(codes.InvalidArgument, "unexpected number of authentication values")
+	ErrFailedToAuthenticate   = status.Error(codes.Unauthenticated, "unable to authenticate user")
+)
+
+// OIDC provides an implementation for the OpenID method of verifying users.
+//
+// Only implements authentication (or "authn" — "who are you")
+//
+// TODO: Implement stream interface
+type OIDC struct {
+	Verifier     *oidc.IDTokenVerifier
+	NeededClaims map[string]map[string]interface{}
+}
+
+// UnaryServerInterceptor provides the implementation of the OIDC handler
+func (o *OIDC) UnaryServerInterceptor(
+	ctx context.Context,
+	req any,
+	_ *grpc.UnaryServerInfo,
+	handler grpc.UnaryHandler,
+) (resp any, err error) {
+	isAuthenticated, err := o.authn(ctx)
+
+	if !isAuthenticated {
+		return nil, err
+	}
+
+	return handler(ctx, req)
+}
+
+// StreamServerInterceptor provides the implementation of the OIDC handler
+func (o *OIDC) StreamServerInterceptor(
+	srv any,
+	ss grpc.ServerStream,
+	_ *grpc.StreamServerInfo,
+	handler grpc.StreamHandler,
+) error {
+	isAuthenticated, err := o.authn(context.Background())
+
+	if !isAuthenticated {
+		return err
+	}
+
+	return handler(srv, ss)
+}
+
+// authn is the implementation of whether or not a given user is allowed to access a resource. Indicates
+// this by returning a bool, and if not allowed, an error describing why.
+func (o *OIDC) authn(ctx context.Context) (bool, error) {
+	m, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return false, ErrMissingMetadata
+	}
+
+	v, ok := m[MetaKeyAuthorization]
+	if !ok {
+		return false, ErrMissingAuthorization
+	}
+
+	if len(v) != 1 {
+		return false, ErrCorruptedAuthorization
+	}
+
+	// TODO: Should be B|b
+	strTok, _ := strings.CutPrefix(v[0], "Bearer ")
+
+	tok, err := o.Verifier.Verify(ctx, strTok)
+
+	if err != nil {
+		return false, fmt.Errorf("%w: %s", ErrFailedToAuthenticate, err)
+	}
+
+	inClaims := make(map[string]interface{}, 0)
+	if err := tok.Claims(&inClaims); err != nil {
+		return false, fmt.Errorf("%w: %s", ErrFailedToAuthenticate, err)
+	}
+
+	return true, nil
+}

--- a/api/dev/url.proto
+++ b/api/dev/url.proto
@@ -21,6 +21,7 @@ message PutRequest {
     string to = 2;
 }
 
+// TODO: Authentication should be an emergent property of these definitions.
 service ManageURLs {
     // Get queries a URL, returning the URL if there was found (or none, if it was not found)
     rpc Get(Request) returns (Response) {}

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -1,6 +1,17 @@
 // Package configuration lists all of the appropriate configuration options, sets defaults and so on.
 package configuration
 
+// OAuth2* is configuration for either requesting or validating OAuth2 keys.
+const (
+	OAuth2ClientID     = "oauth2.client.id"
+	OAuth2ClientSecret = "oauth2.client.secret"
+)
+
+// OIDC* is configuration related to OpenID (an extension, essentially, of OAuth)
+const (
+	OIDCProviderEndpoint = "oidc.provider.endpoint"
+)
+
 // Server* is configuration that modifies how the server is run
 const (
 	ServerListenAddress = "server.listen-address"

--- a/deploy/prod/cr/service.yaml
+++ b/deploy/prod/cr/service.yaml
@@ -25,6 +25,12 @@ spec:
             - "--server.listen-address=0.0.0.0:8080"
             - "--storage.firestore.project=andrewhowdencom"
             - "--server.api.grpc.host=api.x40.link"
+            # This is fine public.
+            # See https://www.oauth.com/oauth2-servers/client-registration/client-id-secret/
+            #
+            # TODO: Secret management for this application.
+            - "--oauth2.client.id=566795814325-k8e5toq16v5plsq54kg2shvtuj9q7vtv.apps.googleusercontent.com"
+            - "--oidc.provider.endpoint=https://accounts.google.com"
           ports:
           # Naming the port H2C gives a hint to Google Clouds load balancing infrastructure that this application
           # supports HTTP/2 without TLS.

--- a/go.mod
+++ b/go.mod
@@ -6,13 +6,17 @@ require (
 	cloud.google.com/go/firestore v1.14.0
 	github.com/andrewhowdencom/sysexits v0.0.0-20230825110138-f9dd56ec6fce
 	github.com/bufbuild/buf v1.28.1
+	github.com/coreos/go-oidc/v3 v3.9.0
 	github.com/go-chi/chi/v5 v5.0.11
+	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.0.1
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.18.2
 	github.com/stretchr/testify v1.8.4
 	go.etcd.io/bbolt v1.3.8
 	golang.org/x/net v0.19.0
+	golang.org/x/oauth2 v0.15.0
+	google.golang.org/api v0.153.0
 	google.golang.org/genproto/googleapis/api v0.0.0-20240108191215-35c7eff3a6b1
 	google.golang.org/grpc v1.60.1
 	google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.3.0
@@ -47,6 +51,7 @@ require (
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/felixge/fgprof v0.9.3 // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
+	github.com/go-jose/go-jose/v3 v3.0.1 // indirect
 	github.com/go-logr/logr v1.3.0 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/gofrs/uuid/v5 v5.0.0 // indirect
@@ -99,14 +104,12 @@ require (
 	golang.org/x/crypto v0.16.0 // indirect
 	golang.org/x/exp v0.0.0-20231110203233-9a3e6036ecaa // indirect
 	golang.org/x/mod v0.14.0 // indirect
-	golang.org/x/oauth2 v0.15.0 // indirect
 	golang.org/x/sync v0.5.0 // indirect
 	golang.org/x/sys v0.15.0 // indirect
 	golang.org/x/term v0.15.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
 	golang.org/x/time v0.5.0 // indirect
 	golang.org/x/tools v0.15.0 // indirect
-	google.golang.org/api v0.153.0 // indirect
 	google.golang.org/appengine v1.6.8 // indirect
 	google.golang.org/genproto v0.0.0-20240102182953-50ed04b92917 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240102182953-50ed04b92917 // indirect

--- a/go.sum
+++ b/go.sum
@@ -41,6 +41,8 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/containerd/stargz-snapshotter/estargz v0.15.1 h1:eXJjw9RbkLFgioVaTG+G/ZW/0kEe2oEKCdS/ZxIyoCU=
 github.com/containerd/stargz-snapshotter/estargz v0.15.1/go.mod h1:gr2RNwukQ/S9Nv33Lt6UC7xEx58C+LHRdoqbEKjz1Kk=
+github.com/coreos/go-oidc/v3 v3.9.0 h1:0J/ogVOd4y8P0f0xUh8l9t07xRP/d8tccvjHl2dcsSo=
+github.com/coreos/go-oidc/v3 v3.9.0/go.mod h1:rTKz2PYwftcrtoCzV5g5kvfJoWcm0Mk8AF8y1iAQro4=
 github.com/cpuguy83/go-md2man/v2 v2.0.3 h1:qMCsGGgs+MAzDFyp9LpAe1Lqy/fY/qCovCm0qnXZOBM=
 github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.18 h1:n56/Zwd5o6whRC5PMGretI4IdRLlmBXYNjScPaBgsbY=
@@ -77,6 +79,8 @@ github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nos
 github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
 github.com/go-chi/chi/v5 v5.0.11 h1:BnpYbFZ3T3S1WMpD79r7R5ThWX40TaFB7L31Y8xqSwA=
 github.com/go-chi/chi/v5 v5.0.11/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=
+github.com/go-jose/go-jose/v3 v3.0.1 h1:pWmKFVtt+Jl0vBZTIpz/eAKwsm6LkIxDVVbFHKkchhA=
+github.com/go-jose/go-jose/v3 v3.0.1/go.mod h1:RNkWWRld676jZEYoV3+XK8L2ZnNSvIsxFMht0mSX+u8=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.3.0 h1:2y3SDp0ZXuc6/cjLSZ+Q3ir+QB9T/iG5yYRXqsagWSY=
 github.com/go-logr/logr v1.3.0/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
@@ -129,6 +133,8 @@ github.com/googleapis/enterprise-certificate-proxy v0.3.2 h1:Vie5ybvEvT75RniqhfF
 github.com/googleapis/enterprise-certificate-proxy v0.3.2/go.mod h1:VLSiSSBs/ksPL8kq3OBOQ6WRI2QnaFynd1DCjZ62+V0=
 github.com/googleapis/gax-go/v2 v2.12.0 h1:A+gCJKdRfqXkr+BIRGtZLibNXf0m1f9E4HG56etFpas=
 github.com/googleapis/gax-go/v2 v2.12.0/go.mod h1:y+aIqrI5eb1YGMVJfuV3185Ts/D7qKpsEkdD5+I6QGU=
+github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.0.1 h1:HcUWd006luQPljE73d5sk+/VgYPGUReEVz2y1/qylwY=
+github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.0.1/go.mod h1:w9Y7gY31krpLmrVU5ZPG9H7l9fZuRu5/3R3S3FMtVQ4=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/ianlancetaylor/demangle v0.0.0-20210905161508-09a460cdf81d/go.mod h1:aYm2/VgdVmcIU8iMfdMvDMsRAQjcfZSKFby6HOFvi/w=
@@ -203,6 +209,7 @@ github.com/stoewer/go-strcase v1.3.0/go.mod h1:fAH5hQ5pehh+j3nZfvwdk2RgEgQjAoM8w
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
@@ -241,6 +248,7 @@ go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN8
 go.uber.org/zap v1.26.0 h1:sI7k6L95XOKS281NhVKOFCUNIvv9e0w4BF8N3u+tCRo=
 go.uber.org/zap v1.26.0/go.mod h1:dtElttAiwGvoJ/vj4IwHBS/gXsEu/pZ50mUIRWuG0so=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/crypto v0.0.0-20190911031432-227b76d455e7/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=

--- a/server/server.go
+++ b/server/server.go
@@ -13,6 +13,7 @@ import (
 	"github.com/go-chi/chi/v5/middleware"
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/h2c"
+	"google.golang.org/grpc"
 )
 
 // Option is a function type that modifies the behavior of the server
@@ -98,7 +99,7 @@ func WithH2C() Option {
 }
 
 // WithGRPC enables GRPC to be served over the
-func WithGRPC(host string) Option {
+func WithGRPC(host string, opts ...grpc.ServerOption) Option {
 	return func(srv *http.Server) error {
 		mux := srv.Handler.(*chi.Mux)
 		filters := []MatcherFunc{
@@ -110,7 +111,7 @@ func WithGRPC(host string) Option {
 			filters = append(filters, IsHost(host))
 		}
 
-		mux.Use(Intercept(AllOf(filters...), api.NewGRPCMux()))
+		mux.Use(Intercept(AllOf(filters...), api.NewGRPCMux(opts...)))
 
 		return nil
 	}


### PR DESCRIPTION
Currently, there is no authentication for this application. This makes
exposing these APIs dangerous, as whomever can come along, crawl and
fuzz them and (even if inadvertently) end up costing me an enormous
amount of money.

This commit implements a very limited authentication.

== Design Notes
=== Style

This commit implements authentication via the OpenID specification. This
specification is an open standard that others can, in principle, also
reuse with this application if they choose to self-host it somewhere.

See:

1. https://openid.net/specs/openid-connect-core-1_0.html

Google Cloud supports OpenID natively via its Cloud resources:

  * https://developers.google.com/identity/protocols/oauth2

Notably, this is also the authentication used for accessing *google
cloud resources*, which means (in particular) if my token gets exposed,
someone gains the same rights I do to the account. Given this, a new
account with no APIs enabled _except_ oAuth has been created, and the
IDs associated given to that.

Long term, something like Auth0 is likely to be a better fit.

=== No authz

This commit does not do any implementation of authz. Currently, I am not
sure of the best way to do this. Initially, I imagined I'd just validate
against a series of scopes per method — but this does not look trivial
to implement.

Given this, we just use authn. There are also no tests, for the minute.

=== No Ownership

This commit does not solve ownership of records — who has access to one,
has access to all right now. This is not a problem while I am the only
one who has access to the application, but will be when more people do.

This requires a rewrite of the storage layer; likely with an interface
that allows asserting ownership of a given record.
