### PR TITLE
Log the metadata from requests

### DIFF
--- a/api/auth/auth.go
+++ b/api/auth/auth.go
@@ -4,6 +4,7 @@ package auth
 import (
 	"context"
 	"fmt"
+	"log"
 	"strings"
 
 	"github.com/coreos/go-oidc/v3/oidc"
@@ -61,7 +62,7 @@ func (o *OIDC) StreamServerInterceptor(
 	_ *grpc.StreamServerInfo,
 	handler grpc.StreamHandler,
 ) error {
-	isAuthenticated, err := o.authn(context.Background())
+	isAuthenticated, err := o.authn(ss.Context())
 
 	if !isAuthenticated {
 		return err
@@ -74,6 +75,10 @@ func (o *OIDC) StreamServerInterceptor(
 // this by returning a bool, and if not allowed, an error describing why.
 func (o *OIDC) authn(ctx context.Context) (bool, error) {
 	m, ok := metadata.FromIncomingContext(ctx)
+
+	log.Println(m)
+	log.Printf("%#v", ctx)
+
 	if !ok {
 		return false, ErrMissingMetadata
 	}


### PR DESCRIPTION
Currently it looks like the authorization header is being dropped from
requests between the client and Google.

This commit seeks to validate that by logging all incoming metadata
(including the authorization header). This is dirty, but no
authenticated requests will be sent in the mean time.
