### PR TITLE
Wire the notion of ownership through the storage implementations

### DIFF
--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1,6 +1,7 @@
 package server_test
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -80,7 +81,7 @@ func TestNewServer_WithStorage(t *testing.T) {
 	t.Parallel()
 
 	storage := test.New()
-	err := storage.Put(&url.URL{
+	err := storage.Put(context.Background(), &url.URL{
 		Host: "test",
 		Path: "/foo",
 	},

--- a/server/storage.go
+++ b/server/storage.go
@@ -20,7 +20,7 @@ func (o *strHandler) Redirect(w http.ResponseWriter, r *http.Request) {
 		Path: r.URL.Path,
 	}
 
-	red, err := o.str.Get(lookup)
+	red, err := o.str.Get(r.Context(), lookup)
 
 	if errors.Is(err, storage.ErrNotFound) {
 		WithError(r, problem.New(

--- a/server/storage_test.go
+++ b/server/storage_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -41,6 +42,7 @@ func TestStoreHandler_Get(t *testing.T) {
 			storage: func() storage.Storer {
 				str := test.New()
 				test.Must(str.Put(
+					context.Background(),
 					&url.URL{Host: "s3k", Path: "/foo"},
 					&url.URL{Scheme: "https", Host: "andrewhowden.com", Path: "/"},
 				))

--- a/storage/boltdb/boltdb.go
+++ b/storage/boltdb/boltdb.go
@@ -2,6 +2,7 @@
 package boltdb
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/url"
@@ -72,7 +73,7 @@ func WithFileLockWait(dur time.Duration) Option {
 }
 
 // Get returns a URL, given another input URL
-func (b *BoltDB) Get(in *url.URL) (*url.URL, error) {
+func (b *BoltDB) Get(_ context.Context, in *url.URL) (*url.URL, error) {
 	var u *url.URL
 
 	if err := b.db.View(func(tx *bbolt.Tx) error {
@@ -102,7 +103,7 @@ func (b *BoltDB) Get(in *url.URL) (*url.URL, error) {
 }
 
 // Put saves a URL to the datastore
-func (b *BoltDB) Put(f *url.URL, t *url.URL) error {
+func (b *BoltDB) Put(_ context.Context, f *url.URL, t *url.URL) error {
 	return b.db.Update(func(tx *bbolt.Tx) error {
 		b, err := tx.CreateBucketIfNotExists(txBucketName)
 		if err != nil {

--- a/storage/firestore/firestore.go
+++ b/storage/firestore/firestore.go
@@ -15,6 +15,15 @@ import (
 	"google.golang.org/grpc/status"
 )
 
+// document is the internal format for the data stored in firestore
+type document struct {
+	// To is where the url should be sent
+	To string `firestore:"to"`
+
+	// Owner is the owner of the document
+	Owner string `firestore:"owner"`
+}
+
 // FirestoreCollection is the collection (in practice, path prefix) for accessing URL content.
 const FirestoreCollection = "links"
 
@@ -25,33 +34,15 @@ type Firestore struct {
 
 // Get fetches a URL from storage
 func (fs Firestore) Get(_ context.Context, url *url.URL) (*url.URL, error) {
-	ctx, cxl := context.WithTimeout(context.Background(), time.Second*30)
-	defer cxl()
 	ref := fs.Client.Doc(urlToPath(url))
-	if ref == nil {
-		return nil, fmt.Errorf("%w: %s", storage.ErrNotFound, "ref not found")
-	}
-
-	doc, err := ref.Get(ctx)
-	if status.Code(err) == codes.NotFound {
-		return nil, fmt.Errorf("%w: %s", storage.ErrNotFound, "document not found")
-	} else if err != nil {
-		return nil, fmt.Errorf("%w: %s", storage.ErrFailed, err)
-	}
-
-	data, err := doc.DataAt("to")
+	doc, err := fs.doc(ref)
 	if status.Code(err) == codes.NotFound {
 		return nil, fmt.Errorf("%w: %s", storage.ErrNotFound, "data at path not found")
 	} else if err != nil {
 		return nil, fmt.Errorf("%w: %s", storage.ErrFailed, err)
 	}
 
-	str, ok := data.(string)
-	if !ok {
-		return nil, fmt.Errorf("%w: received %t (expecting string)", storage.ErrCorrupt, data)
-	}
-
-	to, err := url.Parse(str)
+	to, err := url.Parse(doc.To)
 	if err != nil {
 		return nil, fmt.Errorf("%w: %s", storage.ErrCorrupt, err)
 	}
@@ -60,19 +51,81 @@ func (fs Firestore) Get(_ context.Context, url *url.URL) (*url.URL, error) {
 }
 
 // Put writes a URL into storage
-func (fs Firestore) Put(_ context.Context, from *url.URL, to *url.URL) error {
+// TODO: Write tests for all this.
+func (fs Firestore) Put(ctx context.Context, from *url.URL, to *url.URL) error {
 	ref := fs.Client.Doc(urlToPath(from))
+	agent, _ := ctx.Value(storage.CtxKeyAgent).(string)
 
-	// Try and create the document
-	_, err := ref.Set(context.Background(), map[string]interface{}{
-		"to": to.String(),
-	})
+	// Fetch the owner from the request (if there is one)
+	owner := ""
+	val, ok := ctx.Value(storage.CtxKeyAgent).(string)
+	if ok && val != "" {
+		owner = val
+	}
 
-	if err != nil {
+	// See if there is a document already, and if so, see who owns it.
+	doc, err := fs.doc(ref)
+	status, _ := status.FromError(err)
+
+	if status.Code() != codes.OK && status.Code() != codes.NotFound {
 		return fmt.Errorf("%w: %s", storage.ErrFailed, err)
 	}
 
+	if status.Code() != codes.NotFound && doc.Owner != agent {
+		return storage.ErrUnauthorized
+	}
+
+	// Not found is fine; ownership is fine.
+
+	// Try and create the document
+	_, err = ref.Set(context.Background(), document{
+		To:    to.String(),
+		Owner: owner,
+	})
+
+	if err != nil {
+		return err
+	}
+
 	return nil
+}
+
+// Owns implements the interface validating whether a user actually owns this record.
+func (fs Firestore) Owns(ctx context.Context, u *url.URL) bool {
+	// See who is requesting this data
+	agent, ok := ctx.Value(storage.CtxKeyAgent).(string)
+	if !ok || agent == "" {
+		return false
+	}
+
+	ref := fs.Client.Doc(urlToPath(u))
+	if ref == nil {
+		return false
+	}
+
+	doc, err := fs.doc(ref)
+	if err != nil {
+		return false
+	}
+
+	return doc.Owner == agent
+}
+
+func (fs Firestore) doc(ref *firestore.DocumentRef) (*document, error) {
+	ctx, cxl := context.WithTimeout(context.Background(), time.Second*30)
+	defer cxl()
+
+	doc, err := ref.Get(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	result := &document{}
+	if err := doc.DataTo(result); err != nil {
+		return nil, fmt.Errorf("%w: %s", storage.ErrCorrupt, err)
+	}
+
+	return result, nil
 }
 
 // urlToPath converts the URL into a document ID.

--- a/storage/firestore/firestore.go
+++ b/storage/firestore/firestore.go
@@ -24,7 +24,7 @@ type Firestore struct {
 }
 
 // Get fetches a URL from storage
-func (fs Firestore) Get(url *url.URL) (*url.URL, error) {
+func (fs Firestore) Get(_ context.Context, url *url.URL) (*url.URL, error) {
 	ctx, cxl := context.WithTimeout(context.Background(), time.Second*30)
 	defer cxl()
 	ref := fs.Client.Doc(urlToPath(url))
@@ -60,7 +60,7 @@ func (fs Firestore) Get(url *url.URL) (*url.URL, error) {
 }
 
 // Put writes a URL into storage
-func (fs Firestore) Put(from *url.URL, to *url.URL) error {
+func (fs Firestore) Put(_ context.Context, from *url.URL, to *url.URL) error {
 	ref := fs.Client.Doc(urlToPath(from))
 
 	// Try and create the document

--- a/storage/memory/binary_search.go
+++ b/storage/memory/binary_search.go
@@ -1,6 +1,7 @@
 package memory
 
 import (
+	"context"
 	"net/url"
 	"sync"
 
@@ -65,7 +66,7 @@ func (bs *BinarySearch) find(in *url.URL) (found bool, nearest int) {
 }
 
 // Get returns an URL, given an input URL
-func (bs *BinarySearch) Get(in *url.URL) (*url.URL, error) {
+func (bs *BinarySearch) Get(_ context.Context, in *url.URL) (*url.URL, error) {
 	bs.mu.RLock()
 	defer bs.mu.RUnlock()
 
@@ -79,7 +80,7 @@ func (bs *BinarySearch) Get(in *url.URL) (*url.URL, error) {
 
 // Put writes the record into the set. Takes responsibility for determining the position in which to add the
 // new value, so that the underlying set retains order.
-func (bs *BinarySearch) Put(f *url.URL, t *url.URL) error {
+func (bs *BinarySearch) Put(_ context.Context, f *url.URL, t *url.URL) error {
 	bs.mu.Lock()
 	defer bs.mu.Unlock()
 

--- a/storage/memory/binary_search_test.go
+++ b/storage/memory/binary_search_test.go
@@ -1,6 +1,7 @@
 package memory
 
 import (
+	"context"
 	"net/url"
 	"slices"
 	"testing"
@@ -19,7 +20,7 @@ func TestBinarySearchPutOrder(t *testing.T) {
 		"aiquu4Ev", "Aing2OhD", "YooJooz7"}
 
 	for _, slug := range slugs {
-		err := bs.Put(&url.URL{
+		err := bs.Put(context.Background(), &url.URL{
 			Host: "x40", Path: "/" + slug,
 		}, &url.URL{
 			Host: "andrewhowden.com", Path: "/tests",

--- a/storage/memory/hash_table.go
+++ b/storage/memory/hash_table.go
@@ -1,6 +1,7 @@
 package memory
 
 import (
+	"context"
 	"net/url"
 	"sync"
 
@@ -26,7 +27,7 @@ func NewHashTable() *HashTable {
 
 // Get fetches a URL. It looks it up in the hashmap by converting it to a string representation (which should be
 // unique), after which it will lookup the corresponding URL.
-func (ht *HashTable) Get(in *url.URL) (*url.URL, error) {
+func (ht *HashTable) Get(_ context.Context, in *url.URL) (*url.URL, error) {
 	ht.mu.RLock()
 	defer ht.mu.RUnlock()
 
@@ -39,7 +40,7 @@ func (ht *HashTable) Get(in *url.URL) (*url.URL, error) {
 
 // Put writes a URL into memory. Designed to be used primarily via "loader" infrastructure, such as the
 // YAML loader.
-func (ht *HashTable) Put(f *url.URL, t *url.URL) error {
+func (ht *HashTable) Put(_ context.Context, f *url.URL, t *url.URL) error {
 	ht.mu.Lock()
 	defer ht.mu.Unlock()
 

--- a/storage/memory/hash_table_test.go
+++ b/storage/memory/hash_table_test.go
@@ -1,6 +1,7 @@
 package memory_test
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"net/url"
@@ -34,7 +35,7 @@ func ExampleNewHashTable() {
 		from, _ := url.Parse(tu.f)
 		to, _ := url.Parse(tu.t)
 
-		err := ht.Put(from, to)
+		err := ht.Put(context.Background(), from, to)
 		if err != nil {
 			log.Println(err)
 		}
@@ -44,7 +45,7 @@ func ExampleNewHashTable() {
 	l, _ := url.Parse("x40/a")
 
 	// Normally, we should handle the error from the fetch operation (e.g. not found)
-	ret, _ := ht.Get(l)
+	ret, _ := ht.Get(context.Background(), l)
 	fmt.Println(ret.String())
 	// Output: andrewhowden.com/a
 }
@@ -54,13 +55,13 @@ func TestNewHashTable(t *testing.T) {
 	t.Parallel()
 
 	ht := memory.NewHashTable()
-	assert.Nil(t, ht.Put(&url.URL{
+	assert.Nil(t, ht.Put(context.Background(), &url.URL{
 		Host: "x40",
 	}, &url.URL{
 		Host: "andrewhowden.com",
 	}))
 
-	res, err := ht.Get(&url.URL{
+	res, err := ht.Get(context.Background(), &url.URL{
 		Host: "x40",
 	})
 

--- a/storage/memory/linear_search.go
+++ b/storage/memory/linear_search.go
@@ -1,6 +1,7 @@
 package memory
 
 import (
+	"context"
 	"net/url"
 	"sync"
 
@@ -24,7 +25,7 @@ func NewLinearSearch() *LinearSearch {
 }
 
 // Get queries the linear search. It just iterates through the whole slice.
-func (s *LinearSearch) Get(in *url.URL) (*url.URL, error) {
+func (s *LinearSearch) Get(_ context.Context, in *url.URL) (*url.URL, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
@@ -38,7 +39,7 @@ func (s *LinearSearch) Get(in *url.URL) (*url.URL, error) {
 }
 
 // Put writes the URL into storage, appending it to the slice.
-func (s *LinearSearch) Put(f *url.URL, t *url.URL) error {
+func (s *LinearSearch) Put(_ context.Context, f *url.URL, t *url.URL) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -13,6 +13,7 @@ var (
 	ErrReadOnlyStorage    = errors.New("storage is read only")
 	ErrFailed             = errors.New("storage implementation failed")
 	ErrCorrupt            = errors.New("the data returned by the storage is invalid")
+	ErrUnauthorized       = errors.New("you are not the owner of this record")
 )
 
 // CtxKey is a type designed to allow delimiting key/value pairs

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"context"
 	"errors"
 	"net/url"
 )
@@ -14,12 +15,29 @@ var (
 	ErrCorrupt            = errors.New("the data returned by the storage is invalid")
 )
 
+// CtxKey is a type designed to allow delimiting key/value pairs
+type CtxKey string
+
+const (
+	// CtxKeyAgent is the context address at which the owner will be found, if there is one.
+	CtxKeyAgent CtxKey = "agent"
+)
+
+// Authenticator is an extension to the storage interface that allows verifying whether a given user is the canonical
+// owner of a given URL.
+//
+// Expects to be supplied with a context with the agent stored at the appropriate key. Returns false in the case the
+// user doesn't own the request, or the request cannot be authenticated (e.g. agent is missing)
+type Authenticator interface {
+	Owns(ctx context.Context, u *url.URL) bool
+}
+
 // Storer is the interface that retrieves links supplied to it. Methods are named after the RESTful HTTP
 // verbs, as the meanings are semantically similar.
 type Storer interface {
 	// Get a URL, given a supplied shortlink.
-	Get(url *url.URL) (*url.URL, error)
+	Get(ctx context.Context, url *url.URL) (*url.URL, error)
 
 	// Store a map between a shortlink and the destination.
-	Put(from *url.URL, to *url.URL) error
+	Put(ctx context.Context, from *url.URL, to *url.URL) error
 }

--- a/storage/storage_external_test.go
+++ b/storage/storage_external_test.go
@@ -131,14 +131,14 @@ func TestComplianceExternalAll(t *testing.T) {
 			defer externalSinkTeardown[n]("compliance")
 
 			// Query for a record that doesn't exit, to ensure the data store will not panic.
-			_, err := str.Get(&url.URL{Host: "x40"})
+			_, err := str.Get(context.Background(), &url.URL{Host: "x40"})
 
 			assert.ErrorIs(t, err, storage.ErrNotFound)
 
 			// Insert and query a record.
-			assert.Nil(t, str.Put(&url.URL{Host: "x40"}, &url.URL{Host: "andrewhowden.com"}))
+			assert.Nil(t, str.Put(context.Background(), &url.URL{Host: "x40"}, &url.URL{Host: "andrewhowden.com"}))
 
-			res, err := str.Get(&url.URL{
+			res, err := str.Get(context.Background(), &url.URL{
 				Host: "x40",
 			})
 

--- a/storage/test/test.go
+++ b/storage/test/test.go
@@ -2,6 +2,7 @@
 package test
 
 import (
+	"context"
 	"net/url"
 
 	"github.com/andrewhowdencom/x40.link/storage"
@@ -41,7 +42,7 @@ func WithError(err error) Option {
 }
 
 // see storage.Storer
-func (ts *ts) Get(u *url.URL) (*url.URL, error) {
+func (ts *ts) Get(_ context.Context, u *url.URL) (*url.URL, error) {
 	if ts.err != nil {
 		return nil, ts.err
 	}
@@ -54,7 +55,7 @@ func (ts *ts) Get(u *url.URL) (*url.URL, error) {
 }
 
 // see storage.Storer
-func (ts *ts) Put(f *url.URL, t *url.URL) error {
+func (ts *ts) Put(_ context.Context, f *url.URL, t *url.URL) error {
 	if ts.err != nil {
 		return ts.err
 	}

--- a/storage/yaml/yaml.go
+++ b/storage/yaml/yaml.go
@@ -1,6 +1,7 @@
 package yaml
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"log/slog"
@@ -61,7 +62,7 @@ func New(str storage.Storer, src io.Reader) (*yaml, error) {
 
 		fmt.Println(from.String(), to.String())
 
-		if err := y.str.Put(from, to); err != nil {
+		if err := y.str.Put(context.Background(), from, to); err != nil {
 			return nil, fmt.Errorf("%w: %s", storage.ErrStorageSetupFailed, err)
 		}
 	}
@@ -69,10 +70,10 @@ func New(str storage.Storer, src io.Reader) (*yaml, error) {
 	return y, nil
 }
 
-func (y *yaml) Get(u *url.URL) (*url.URL, error) {
-	return y.str.Get(u)
+func (y *yaml) Get(ctx context.Context, u *url.URL) (*url.URL, error) {
+	return y.str.Get(ctx, u)
 }
 
-func (y *yaml) Put(*url.URL, *url.URL) error {
+func (y *yaml) Put(context.Context, *url.URL, *url.URL) error {
 	return storage.ErrReadOnlyStorage
 }

--- a/storage/yaml/yaml_test.go
+++ b/storage/yaml/yaml_test.go
@@ -2,6 +2,7 @@ package yaml_test
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"io"
 	"log/slog"
@@ -95,7 +96,7 @@ func TestNewYaml(t *testing.T) {
 
 			// Validate State
 			for _, u := range tc.urls {
-				nu, err := y.Get(u.f)
+				nu, err := y.Get(context.Background(), u.f)
 				assert.ErrorIs(t, err, u.err)
 				assert.Equal(t, u.t, nu)
 			}
@@ -110,6 +111,7 @@ func TestYamlRejectWrite(t *testing.T) {
 	assert.Nil(t, err)
 
 	err = y.Put(
+		context.Background(),
 		&url.URL{Host: "x40", Path: "/foo"},
 		&url.URL{Host: "k3s", Path: "/bar"},
 	)


### PR DESCRIPTION
Currently, work is going on to implement an API for this service,
including ensuring that a (multi-tenant) userbase cannot overwrite each
others records. This commit implements the path for a first, naive
approach at this: Introducing ownership to storage engines.

It does this by providing an interface an engine can (optionally)
implement which allows us to check whether a given agent (supplied by
string) is the "owner" of a given record. This, in turn, allows us to
check whether a record should be updatable (or deletable).

== Design Notes
=== Simple Design

This design is deliberately extremely simple. The appropriate solution
looks to be something like ReBAC¹, but this will take a long time to
write manually, and there's nothing yet that balances the desire to have
this open source and widely usable with the desire to host it in Google
Cloud.

Interestingly, Google Cloud itself does not offer a Zanzibar like
approach, despite apparently releasing the idea²

—
1. https://en.wikipedia.org/wiki/Relationship-based_access_control
2. https://research.google/pubs/zanzibar-googles-consistent-global-authorization-system/
