### PR TITLE
Propagate context to storage

### DIFF
--- a/storage/firestore/firestore.go
+++ b/storage/firestore/firestore.go
@@ -75,8 +75,6 @@ func (fs Firestore) Put(ctx context.Context, from *url.URL, to *url.URL) error {
 		return storage.ErrUnauthorized
 	}
 
-	// Not found is fine; ownership is fine.
-
 	// Try and create the document
 	_, err = ref.Set(context.Background(), document{
 		To:    to.String(),

--- a/storage/storage_external_test.go
+++ b/storage/storage_external_test.go
@@ -186,6 +186,12 @@ func TestOwnership(t *testing.T) {
 			to, err := str.Get(thiefCtx, &url.URL{Host: "x40"})
 			assert.Nil(t, err)
 			assert.Equal(t, to.String(), (&url.URL{Host: "40x"}).String())
+
+			// Do not allow anonymous users to update the record
+			assert.ErrorIs(t,
+				str.Put(context.Background(), &url.URL{Host: "x40"}, &url.URL{Host: "x40"}),
+				storage.ErrUnauthorized,
+			)
 		})
 	}
 }


### PR DESCRIPTION
Currently there is a problem in that the context that is created in the
oidc layer is not propagated all the way to the storage layer (and thus,
the storage layer cannot make any decisions about how it is used).

This commit addresses that by wiring through the context some places it
had been missed.
