### PR TITLE
Implement the server

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -13,12 +13,13 @@ vars:
 tasks:
   bin:
     desc: "Build a go binary specific to an architecture and operating system"
+    deps:
+      - "protobuf/generate"
     requires:
       vars: [GOOS, GOARCH]
     cmds:
       # Generate the required files
       - mkdir -p "dist/{{ .GOOS }}+{{ .GOARCH }}"
-      - cd api && buf generate
       - go build -o "dist/{{ .GOOS }}+{{ .GOARCH }}/x40.link{{ exeExt }}"
 
   bin/all:
@@ -151,6 +152,12 @@ tasks:
     dir: "./docs"
     cmds:
       - "poetry run mkdocs serve"
+
+  protobuf/generate:
+    desc: "Generates the code required to interact with protobuf definitions"
+    cmds:
+      - cd api && buf generate
+
 
   tofu/plan:
     desc: "Plan the infrastructure changes, and validate their output"

--- a/api/api.go
+++ b/api/api.go
@@ -3,16 +3,18 @@
 package api
 
 import (
-	"github.com/andrewhowdencom/x40.link/api/gen/dev"
+	"github.com/andrewhowdencom/x40.link/api/dev"
+	gendev "github.com/andrewhowdencom/x40.link/api/gen/dev"
+	"github.com/andrewhowdencom/x40.link/storage"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/reflection"
 )
 
 // NewGRPCMux generates a valid GRPC server with all GRPC routes configured.
-func NewGRPCMux(opts ...grpc.ServerOption) *grpc.Server {
+func NewGRPCMux(storer storage.Storer, opts ...grpc.ServerOption) *grpc.Server {
 	m := grpc.NewServer(opts...)
 
-	dev.RegisterManageURLsServer(m, &dev.UnimplementedManageURLsServer{})
+	gendev.RegisterManageURLsServer(m, &dev.URL{Storer: storer})
 
 	reflection.Register(m)
 

--- a/api/dev/url.go
+++ b/api/dev/url.go
@@ -1,0 +1,75 @@
+// Package dev implements a GRPC server that reads and writes URLs to storage.
+package dev
+
+import (
+	"context"
+	"errors"
+	"log"
+	"net/url"
+
+	"github.com/andrewhowdencom/x40.link/api/gen/dev"
+	"github.com/andrewhowdencom/x40.link/storage"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/emptypb"
+)
+
+// URL is an implementation of the URL gRPC Server
+type URL struct {
+	Storer storage.Storer
+
+	dev.UnimplementedManageURLsServer
+}
+
+// Get fetches a URL from storage
+func (u URL) Get(ctx context.Context, req *dev.Request) (*dev.Response, error) {
+	url, err := url.Parse(req.Url)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "url parse failure: %s", err)
+	}
+
+	response, err := u.Storer.Get(ctx, url)
+	if errors.Is(err, storage.ErrUnauthorized) {
+		return nil, status.Error(codes.PermissionDenied, "you are not the owner of this record")
+	} else if errors.Is(err, storage.ErrNotFound) {
+		return nil, status.Error(codes.NotFound, "url not found")
+	} else if err != nil {
+
+		log.Println(err)
+		return nil, status.Error(codes.Internal, "internal server error")
+	}
+
+	return &dev.Response{
+		Url: response.String(),
+	}, nil
+}
+
+// New generates the "from" URL on the fly, based on request metadata.
+func (URL) New(context.Context, *dev.Request) (*dev.Response, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method Post not implemented")
+}
+
+// NewCustom writes a new URL into storage
+func (u URL) NewCustom(ctx context.Context, req *dev.CustomRequest) (*emptypb.Empty, error) {
+	urls := [2]*url.URL{}
+
+	for i, v := range []string{req.From, req.To} {
+		url, err := url.Parse(v)
+		if err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "url parse failure: %s", err)
+		}
+
+		urls[i] = url
+	}
+
+	err := u.Storer.Put(ctx, urls[0], urls[1])
+
+	if errors.Is(err, storage.ErrUnauthorized) {
+		return nil, status.Error(codes.PermissionDenied, "you are not the owner of this record")
+	} else if err != nil {
+		log.Println(err)
+		return nil, status.Errorf(codes.Internal, "failed to write to storage")
+	}
+
+	return &emptypb.Empty{}, nil
+}

--- a/api/dev/url.proto
+++ b/api/dev/url.proto
@@ -10,25 +10,24 @@ message Request {
     string url = 1;
 }
 
-// Response
 message Response {
     string url = 1;
 }
 
-// PutRequest
-message PutRequest {
+message CustomRequest {
     string from = 1;
     string to = 2;
 }
 
 // TODO: Authentication should be an emergent property of these definitions.
+// Come back to when looking at ReBAC
 service ManageURLs {
     // Get queries a URL, returning the URL if there was found (or none, if it was not found)
     rpc Get(Request) returns (Response) {}
 
     // Post generates a new URL with a generated suffix.
-    rpc Post(Request) returns (Response) {}
+    rpc New(Request) returns (Response) {}
 
     // Put writes a new URL to the store
-    rpc Put(PutRequest) returns (google.protobuf.Empty) {}
+    rpc NewCustom(CustomRequest) returns (google.protobuf.Empty) {}
 }

--- a/api/dev/url_test.go
+++ b/api/dev/url_test.go
@@ -1,0 +1,183 @@
+package dev_test
+
+import (
+	"context"
+	"errors"
+	"net/url"
+	"testing"
+
+	"github.com/andrewhowdencom/x40.link/api/dev"
+	gendev "github.com/andrewhowdencom/x40.link/api/gen/dev"
+	"github.com/andrewhowdencom/x40.link/storage"
+	"github.com/andrewhowdencom/x40.link/storage/test"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestGetURL(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+
+		// Used to construct the interface
+		str storage.Storer
+		req *gendev.Request
+
+		resp *gendev.Response
+		code codes.Code
+	}{
+		{
+			name: "bad url",
+
+			str: test.New(),
+			req: &gendev.Request{
+				Url: "\x00",
+			},
+
+			resp: nil,
+			code: codes.InvalidArgument,
+		},
+		{
+			name: "url not found",
+			str:  test.New(),
+			req: &gendev.Request{
+				Url: "https://example.local",
+			},
+
+			resp: nil,
+			code: codes.NotFound,
+		},
+		{
+			name: "unauthorized",
+			str:  test.New(test.WithError(storage.ErrUnauthorized)),
+			req: &gendev.Request{
+				Url: "https://example.local",
+			},
+
+			resp: nil,
+			code: codes.PermissionDenied,
+		},
+		{
+			name: "storage failure",
+			str:  test.New(test.WithError(errors.New("b0rked"))),
+			req: &gendev.Request{
+				Url: "https://example.local",
+			},
+			resp: nil,
+			code: codes.Internal,
+		},
+		{
+			name: "all ok",
+			str: func() storage.Storer {
+				test := test.New()
+				if err := test.Put(
+					context.Background(),
+					&url.URL{Scheme: "https", Host: "example.local", Path: "/"},
+					&url.URL{Scheme: "https", Host: "example.local", Path: "/"},
+				); err != nil {
+					panic("problem setting up test case: " + err.Error())
+				}
+
+				return test
+			}(),
+			req: &gendev.Request{
+				Url: "https://example.local/",
+			},
+			resp: &gendev.Response{
+				Url: "https://example.local/",
+			},
+			code: codes.OK,
+		},
+	} {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv := &dev.URL{
+				Storer: tc.str,
+			}
+
+			resp, err := srv.Get(context.Background(), tc.req)
+
+			assert.Equal(t, tc.resp, resp)
+
+			// nil error is codes.OK and isStatus.
+			status, isStatus := status.FromError(err)
+			assert.True(t, isStatus)
+			assert.Equal(t, tc.code, status.Code())
+		})
+	}
+}
+
+func TestNewCustom(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+
+		str storage.Storer
+		req *gendev.CustomRequest
+
+		code codes.Code
+	}{
+		{
+			name: "bad from url",
+			str:  nil,
+			req: &gendev.CustomRequest{
+				From: "\x00",
+				To:   "https://example.local",
+			},
+
+			code: codes.InvalidArgument,
+		},
+		{
+			name: "bad to url",
+
+			str: nil,
+			req: &gendev.CustomRequest{
+				From: "https://example.local",
+				To:   "\x00",
+			},
+
+			code: codes.InvalidArgument,
+		},
+		{
+			name: "unauthorized",
+			str:  test.New(test.WithError(storage.ErrUnauthorized)),
+			req: &gendev.CustomRequest{
+				From: "https://example.local",
+				To:   "https://example.local/2",
+			},
+
+			code: codes.PermissionDenied,
+		},
+		{
+			name: "failure to write",
+			str:  test.New(test.WithError(errors.New("b0rked"))),
+			req: &gendev.CustomRequest{
+				From: "https://example.local",
+				To:   "https://example.local/2",
+			},
+			code: codes.Internal,
+		},
+		{
+			name: "all ok",
+			str:  test.New(),
+			req: &gendev.CustomRequest{
+				From: "https://example.local",
+				To:   "https://example.local/2",
+			},
+			code: codes.OK,
+		},
+	} {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+		})
+	}
+}

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -120,7 +120,7 @@ func RunServe(cmd *cobra.Command, _ []string) error {
 	}
 
 	if apiHost != "" || cmd.Flags().Lookup(configuration.ServerAPIGRPCHost).Changed {
-		args = append(args, server.WithGRPC(apiHost, apiOpts...))
+		args = append(args, server.WithGRPC(str, apiHost, apiOpts...))
 	}
 
 	args = append(args,

--- a/server/server.go
+++ b/server/server.go
@@ -99,7 +99,7 @@ func WithH2C() Option {
 }
 
 // WithGRPC enables GRPC to be served over the
-func WithGRPC(host string, opts ...grpc.ServerOption) Option {
+func WithGRPC(storer storage.Storer, host string, opts ...grpc.ServerOption) Option {
 	return func(srv *http.Server) error {
 		mux := srv.Handler.(*chi.Mux)
 		filters := []MatcherFunc{
@@ -111,7 +111,7 @@ func WithGRPC(host string, opts ...grpc.ServerOption) Option {
 			filters = append(filters, IsHost(host))
 		}
 
-		mux.Use(Intercept(AllOf(filters...), api.NewGRPCMux(opts...)))
+		mux.Use(Intercept(AllOf(filters...), api.NewGRPCMux(storer, opts...)))
 
 		return nil
 	}


### PR DESCRIPTION
With the implementation of authentication (and the limit of that
authentication to the andrewhowden.com organization), this project can
(relatively safely) implement the API.

This commit does that.

== Design Notes
=== Renaming Methods

This commit renames the existing methods to be something more "RPC
Friendly". Historicaly, the names were derived from the RESTful HTTP
layer they were trying to emulate.

While thinking about transactions in a RESTful way is still a useful
idea for state management, naming the methods after the HTTP verbs
doesn't make as much sense.

The names are now:

* Get → Get (Still Valid)
* Post → New (The most common method)
* Post → NewCustom (The exception, where we're creating new URLs)

=== Updates to Taskfile

While generating the new definitions, I noticed that the existing design
doesn't let us generate outside a build (e.g. during development), and
during the build, its invoked every time bin is called — it only needs
to be done once.

This commit splits out the task so it can be invoked seperately, and
adds it as a dependency to bin so its only called once.

=== Partial Implementation

This commit only partially implements the desired API — specifically,
the method "POST" is currently not implemented.

This method relies on something generating UUIDs for these URLs, which
hasn't yet been generated.
