### PR TITLE
Implement the "New" function

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -6,6 +6,7 @@ import (
 	"github.com/andrewhowdencom/x40.link/api/dev"
 	gendev "github.com/andrewhowdencom/x40.link/api/gen/dev"
 	"github.com/andrewhowdencom/x40.link/storage"
+	"github.com/andrewhowdencom/x40.link/uid"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/reflection"
 )
@@ -14,7 +15,13 @@ import (
 func NewGRPCMux(storer storage.Storer, opts ...grpc.ServerOption) *grpc.Server {
 	m := grpc.NewServer(opts...)
 
-	gendev.RegisterManageURLsServer(m, &dev.URL{Storer: storer})
+	gendev.RegisterManageURLsServer(m, &dev.URL{
+		Storer: storer,
+		Enricher: (&dev.URLEnricher{
+			Domain: "x40.link",
+			Path:   uid.New(uid.TypeRandom),
+		}).Enrich,
+	})
 
 	reflection.Register(m)
 

--- a/api/dev/url.proto
+++ b/api/dev/url.proto
@@ -5,8 +5,16 @@ option go_package = "github.com/andrewhowdencom/x40/api/gen/dev";
 import "google/api/annotations.proto";
 import "google/protobuf/empty.proto";
 
-// Request
-message Request {
+// URL is a type representing the URL that should be created.
+//
+// The definition expects any fields that are missing to be generated on the server side.
+message RedirectOn {
+    string host = 1;
+    string path = 2;
+}
+
+// GetRequest fetches a URL
+message GetRequest {
     string url = 1;
 }
 
@@ -14,20 +22,19 @@ message Response {
     string url = 1;
 }
 
-message CustomRequest {
-    string from = 1;
-    string to = 2;
+// NewRequest generates a URL at the desired domain.
+message NewRequest {
+    RedirectOn on = 1;
+    string sendTo = 2;
 }
+
 
 // TODO: Authentication should be an emergent property of these definitions.
 // Come back to when looking at ReBAC
 service ManageURLs {
     // Get queries a URL, returning the URL if there was found (or none, if it was not found)
-    rpc Get(Request) returns (Response) {}
+    rpc Get(GetRequest) returns (Response) {}
 
     // Post generates a new URL with a generated suffix.
-    rpc New(Request) returns (Response) {}
-
-    // Put writes a new URL to the store
-    rpc NewCustom(CustomRequest) returns (google.protobuf.Empty) {}
+    rpc New(NewRequest) returns (Response) {}
 }

--- a/uid/uid.go
+++ b/uid/uid.go
@@ -1,0 +1,91 @@
+// Package uid (or unique ID) provides mechanisms of generating the slugs for URLs.
+package uid
+
+import (
+	"crypto/rand"
+	"errors"
+	"fmt"
+	"math/big"
+	"net/url"
+)
+
+// Type* are prefixes that are applied to the ID so that as new IDs are produced from different mechanisms,
+// they do not collide.
+//
+// Exists to "future-proof" generations, in case it turns out one is prone to collisions.
+const (
+	TypeRandom byte = 1
+
+	// Not intended for production use.
+	TypeFails  byte = 90
+	TypeStatic byte = 91
+)
+
+// Err* are sentinel errors
+var (
+	ErrFailed = errors.New("failed to generate id")
+)
+
+// funcMap calls the appropriate function based on the sentinel byte.
+var funcMap = map[byte]func(u *url.URL) ([]byte, error){
+	TypeRandom: Rand,
+
+	// Testing
+	TypeFails:  Failing,
+	TypeStatic: Static([]byte{00, 00, 00, 00}),
+}
+
+// Generator is the type that receives a URL and returns an ID. Note: Not all generators derive their values
+// from the URL.
+type Generator struct {
+	t byte
+}
+
+// New generates a generator which transforms the input URL to something
+func New(t byte) *Generator {
+	_, ok := funcMap[t]
+	if !ok {
+		panic("invalid generator provided: " + string(t))
+	}
+
+	return &Generator{t: t}
+}
+
+// ID converts the returned byte array to the base62 representation, complete with prefix.
+func (g *Generator) ID(u *url.URL) (string, error) {
+	id, err := funcMap[g.t](u)
+	if err != nil {
+		return "", fmt.Errorf("%w: %s", ErrFailed, err)
+	}
+
+	var i big.Int
+	m := append([]byte{g.t}, id...)
+	i.SetBytes(m)
+
+	return i.Text(62), nil
+}
+
+// Rand returns a random, 3 byte value. 3 bytes is ~8M (signed); when the number of URLs for this
+// collides, I'll have bigger problems than just the collisions.
+func Rand(_ *url.URL) ([]byte, error) {
+	tok := make([]byte, 3)
+	_, err := rand.Read(tok)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return tok, nil
+}
+
+// Failing is a generator that just fails. Used for testing.
+func Failing(_ *url.URL) ([]byte, error) {
+	return nil, errors.New("i failed")
+}
+
+// Static is a generator that returns a static set of bytes. Used for testing.
+func Static(s []byte) func(*url.URL) ([]byte, error) {
+	return func(u *url.URL) ([]byte, error) {
+		return s, nil
+	}
+}

--- a/uid/uid_test.go
+++ b/uid/uid_test.go
@@ -1,0 +1,27 @@
+package uid_test
+
+import (
+	"math/big"
+	"net/url"
+	"testing"
+
+	"github.com/andrewhowdencom/x40.link/uid"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestRand just tests whether rand generates any value.
+func TestRand(t *testing.T) {
+	t.Parallel()
+
+	// Generate the number
+	g := uid.New(uid.TypeRandom)
+	v, err := g.ID(&url.URL{})
+
+	assert.Nil(t, err)
+	assert.NotEqual(t, "", v)
+
+	// Convert back to its number, and validate the first byte is the prefix.
+	var i big.Int
+	i.SetString(v, 62)
+	assert.Equal(t, uid.TypeRandom, i.Bytes()[0])
+}


### PR DESCRIPTION
This commit implements the new function, within the URL. While doing
this, quite a bit became clear about the design of the API that would
allow it to be simplified.

== Design Notes
=== Removing custom, replacing with enricher

The difference between the New and the NewCustom methods was the
existance of a path. However, what became clear when the New method was
being created was that *both* the path and the slug would need to be
generated. With that both being there, it became clear that there could
be a single function which simply generated the content that was
missing.

The old function was renamed, and the protobuf definitions updated. A
new type (Enricher) was created to polyfill the information that is
missing.

=== Hardcoded x40.link default

The enricher configuration currently has a hard-coded link of x40.link
as a default.

This is just laziness. I need to figure out a way to reduce the
complexity in cmd.Serve(), which I think will be dependency injection.
Then, we can figure out how to dependency inject configuration (perhaps
by storing specific types in Viper).

At that point, the default will be configurable.

=== General design for UID

This commit also implements a simple generator for the slugs. The focus
for this generator is not necessarily uniqueness, but rather forward
compatibility. This is because it is very unlikely that I will figure
out the right algorithm in the initial pass; instead, I want to be able
to evolve the algorithm going forward.

To this end, the algorithm just samples random data, and converts it to
base64 to have a more compact representation of it. Its prefixed with a
type, so that if needed in future, the algorithm can be swapped out and
the old URLs preserved.

=== Testing implements in uid

There are generators in the uid generation, including testing
generators. This just allows easier validation of the UI.
