### PR TITLE
Shift the tokens into a separate, JWT package

### DIFF
--- a/api/auth/jwts/jwts.go
+++ b/api/auth/jwts/jwts.go
@@ -1,5 +1,5 @@
-// Package tokens provides various different JWT tokens.
-package tokens
+// Package jwts provides various different JWT tokens.
+package jwts
 
 import "github.com/golang-jwt/jwt/v5"
 
@@ -90,6 +90,6 @@ type X40 struct {
 	*OIDC
 
 	// Roles are the roles the application users may have. Long term, this should be deprecated and removed in
-	// favor of ReBAC but for now, it persists.
+	// favor of ReBAC but for now, it
 	Roles []string `json:"x40.link/roles"`
 }

--- a/api/auth/oidc_test.go
+++ b/api/auth/oidc_test.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/andrewhowdencom/x40.link/api/auth"
-	"github.com/andrewhowdencom/x40.link/api/auth/tokens"
+	"github.com/andrewhowdencom/x40.link/api/auth/jwts"
 	"github.com/andrewhowdencom/x40.link/storage"
 	"github.com/coreos/go-oidc/v3/oidc"
 	"github.com/golang-jwt/jwt/v5"
@@ -85,8 +85,8 @@ func TestOIDCAuthCtx(t *testing.T) {
 		{
 			name: "no role",
 			ctx: func() context.Context {
-				oTok := &tokens.OIDC{
-					Default: &tokens.Default{
+				oTok := &jwts.OIDC{
+					Default: &jwts.Default{
 						Issuer:  issuer,
 						Subject: "e7e90d06-b60b-11ee-993a-5bf4ddaa2f8d",
 
@@ -103,7 +103,7 @@ func TestOIDCAuthCtx(t *testing.T) {
 				}
 
 				tok := jwt.NewWithClaims(jwt.SigningMethodRS256, oTok)
-				sTok, err := tok.SignedString(pkey)
+				sTok, err := tok.SignedString(pkey) //nolint:all false positive
 				if err != nil {
 					panic("failed to create token: " + err.Error())
 				}
@@ -147,8 +147,8 @@ func TestOIDCAuthCtx(t *testing.T) {
 		{
 			name: "all ok, has agent context",
 			ctx: func() context.Context {
-				oTok := &tokens.X40{
-					Default: &tokens.Default{
+				oTok := &jwts.X40{
+					Default: &jwts.Default{
 						Issuer:  issuer,
 						Subject: "e7e90d06-b60b-11ee-993a-5bf4ddaa2f8d",
 
@@ -159,7 +159,7 @@ func TestOIDCAuthCtx(t *testing.T) {
 						Expiration: jwt.NewNumericDate(time.Now().Add(time.Hour * 4)),
 					},
 
-					OIDC: &tokens.OIDC{
+					OIDC: &jwts.OIDC{
 						Name:   "Test User",
 						Email:  "test-user@example.local",
 						Locale: "en_GB",


### PR DESCRIPTION
Currently there is a little bit of confusing terminology. There are:

1. "Tokens" in the sense of OAuth, such an access or refresh token.
   These are opaque tokens to the spec¹
2. "JSON Web Tokens", which are commonly a format for the data chunk of
   an access token.

In addition, there's OpenID which includes a "non-standard" OAuth2 field
called "token_id", which *is* a JSON web token.

This commit tries to resolve this ambiguity by putting the JWTs in a
package called JWT.

—
1. https://www.oauth.com/oauth2-servers/access-tokens/
2. https://oauth.net/id-tokens-vs-access-tokens/
