### PR TITLE
Introduce k/v storage layer

### DIFF
--- a/api/auth/tokens/storage/storage.go
+++ b/api/auth/tokens/storage/storage.go
@@ -1,0 +1,75 @@
+// Package storage provides storage for the cachable token interface.
+package storage
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+)
+
+// Err* are sentinel errors.
+var (
+	ErrNotFound       = errors.New("token not found")
+	ErrStorageFailure = errors.New("storage failure")
+)
+
+// Storage is the interface that stores and retrieves bytes from disk. It is ... similar to the io.ReadWriter,
+// except the Read/Write methods make assumptions that the underlying data should be truncated before
+// new data is written in, and that users always want the full set of bytes.
+type Storage interface {
+	Read() ([]byte, error)
+	Write([]byte) error
+}
+
+// File provides simple file-backed storage for the token interface.
+type File struct {
+	Path string
+}
+
+// Read implements storage.Read
+func (f *File) Read() ([]byte, error) {
+	fh, err := os.Open(f.Path)
+
+	// We treat a file not being found as a token that is not created yet, as this is
+	// the case that may happen.
+	if err != nil && os.IsNotExist(err) {
+		return nil, ErrNotFound
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("%w: %s", ErrStorageFailure, err)
+	}
+
+	b, err := io.ReadAll(fh)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %s", ErrStorageFailure, err)
+	}
+
+	return b, nil
+}
+
+// Write implements storage.Write. It uses a swap file and rename operation to ensure the change is
+// atomic.
+func (f *File) Write(bytes []byte) error {
+	nf := f.Path + ".swp"
+	nfh, err := os.OpenFile(nf, os.O_RDWR|os.O_CREATE, 0o600)
+	if err != nil {
+		return fmt.Errorf("%w: %s", ErrStorageFailure, err)
+	}
+
+	_, err = nfh.Write(bytes)
+	if err != nil {
+		return fmt.Errorf("%w: %s", ErrStorageFailure, err)
+	}
+
+	if err := nfh.Close(); err != nil {
+		return fmt.Errorf("%w: %s", ErrStorageFailure, err)
+	}
+
+	if err := os.Rename(nf, f.Path); err != nil {
+		return fmt.Errorf("%w: %s", ErrStorageFailure, err)
+	}
+
+	return nil
+}

--- a/api/auth/tokens/storage/storage_test.go
+++ b/api/auth/tokens/storage/storage_test.go
@@ -1,0 +1,160 @@
+package storage_test
+
+import (
+	"os"
+	"path"
+	"strings"
+	"testing"
+
+	"github.com/andrewhowdencom/x40.link/api/auth/tokens/storage"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStorageRW(t *testing.T) {
+	// Create a new directory to use as the psuedo root for this package
+	dir, err := os.MkdirTemp("", "test-storage-rw-*")
+	if err != nil {
+		t.Fatalf("unable to make test dir: %s", err.Error())
+	}
+
+	// Clean up that directory (and all its children)
+	defer func() {
+		if err := os.RemoveAll(dir); err != nil {
+			t.Logf("failed to clean up test dir: %s", err.Error())
+		}
+	}()
+
+	// Give each subtest its own directory
+	td := func(name string) string {
+		dir, err := os.MkdirTemp(dir, strings.ReplaceAll(name, " ", "-"))
+		if err != nil {
+			t.Fatalf("failed to make test directory for %s: %s", name, err.Error())
+		}
+
+		return dir
+	}
+
+	for _, tc := range []struct {
+		name string
+		file *storage.File
+
+		setup func(inDir string)
+
+		// function list
+		fl      []interface{}
+		err     []error
+		results [][]byte
+	}{
+		{
+			name: "file not found",
+			file: &storage.File{
+				Path: "foo.json",
+			},
+
+			setup: func(name string) {},
+			fl: []interface{}{
+				func(f *storage.File) ([]byte, error) {
+					return f.Read()
+				},
+			},
+			err: []error{
+				storage.ErrNotFound,
+			},
+			results: [][]byte{
+				nil,
+			},
+		},
+		{
+			name: "file is directory",
+			file: &storage.File{
+				Path: "foo",
+			},
+			setup: func(inDir string) {
+				if err := os.Mkdir(path.Join(inDir, "foo"), 0o755); err != nil {
+					t.Fatalf("unable create test dir: %s", err.Error())
+				}
+			},
+			fl: []interface{}{
+				func(f *storage.File) ([]byte, error) {
+					return f.Read()
+				},
+			},
+
+			err: []error{
+				storage.ErrStorageFailure,
+			},
+			results: [][]byte{
+				nil,
+			},
+		},
+		{
+			name: "can write to path",
+			file: &storage.File{
+				Path: "foo.json",
+			},
+			setup: func(inDir string) {},
+			fl: []interface{}{
+				func(f *storage.File) error {
+					return f.Write([]byte("Im going in the file!"))
+				},
+			},
+			err: []error{
+				nil,
+			},
+			results: [][]byte{},
+		},
+		{
+			name: "can read back what was written",
+			file: &storage.File{
+				Path: "foo.json",
+			},
+			setup: func(inDir string) {},
+			fl: []interface{}{
+				func(f *storage.File) error {
+					return f.Write([]byte("Im going in the file!"))
+				},
+				func(f *storage.File) ([]byte, error) {
+					return f.Read()
+				},
+			},
+			err:     []error{nil, nil},
+			results: [][]byte{[]byte("Im going in the file!")},
+		},
+	} {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			dir := td(tc.name)
+			tc.setup(dir)
+
+			// Ensure that the path is relative to the newly created temporary directory.
+			tc.file.Path = path.Join(dir, tc.file.Path)
+
+			err := []error{}
+			results := [][]byte{}
+
+			// Run the function stack
+			for _, f := range tc.fl {
+				switch vf := f.(type) {
+				case func(f *storage.File) ([]byte, error):
+					r, e := vf(tc.file)
+					err = append(err, e)
+					results = append(results, r)
+				case func(f *storage.File) error:
+					err = append(err, vf(tc.file))
+				default:
+					t.Fatal("function supplied but not executable")
+				}
+			}
+
+			// Compare the results
+			for i := range tc.err {
+				assert.ErrorIs(t, err[i], tc.err[i])
+			}
+
+			for i := range tc.results {
+				assert.Equalf(t, tc.results[i], results[i], "byte construct not equal")
+			}
+		})
+	}
+}


### PR DESCRIPTION
Currently work is in progress to define a client for the x40
application. This client needs to store an access and a refresh token
_somewhere_, and it cannot store it on memory. this commit provides some
of the content required to keep that storage on disk.

== Design Notes
=== Storage Interface

This commit provides storage via an _interface_, rather than directly
using the file. It turns out, this is a tricky problem in open source
software generally — the goal here is to create a pluggable interface,
and perhaps (in future) another design where we can persist it via
boltdb or similar.
