### PR TITLE
Add storage backed token source

### DIFF
--- a/api/auth/tokens/seeds/seeds.go
+++ b/api/auth/tokens/seeds/seeds.go
@@ -12,6 +12,8 @@ import (
 
 // Err* are sentinel errors
 var (
+	ErrFailed = errors.New("seed failed")
+
 	ErrFailedToExchange     = errors.New("failed to exchange token")
 	ErrFailedToGetDeviceURL = errors.New("failed to get device url")
 )

--- a/api/auth/tokens/source.go
+++ b/api/auth/tokens/source.go
@@ -1,0 +1,160 @@
+// Package tokens provides an implementation to fetch and manage OAuth2 tokens.
+package tokens
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/andrewhowdencom/x40.link/api/auth/tokens/seeds"
+	"github.com/andrewhowdencom/x40.link/api/auth/tokens/storage"
+	"golang.org/x/oauth2"
+)
+
+// Err* are sentinel errors for this package.
+var (
+	ErrCacheSetupFailed = errors.New("cache setup failed")
+	ErrCacheFailure     = errors.New("cache failure")
+)
+
+// CachingSource is an implementation of TokenSource that will attempt to read the token from a cache.
+// If it finds a valid token in the case, it'll use it. If not, it'll use the supplied "seed function"
+// to fetch a new token.
+type CachingSource struct {
+	ts oauth2.TokenSource
+
+	// Cur is the previously seen access token.
+	cur *oauth2.Token
+
+	// Storage is the me
+	str storage.Storage
+}
+
+// NewReuseTokenSource is the anticipated default token source for the caching source to wrap.
+func NewReuseTokenSource(cfg *oauth2.Config) func(context.Context, *oauth2.Token) oauth2.TokenSource {
+	return func(ctx context.Context, t *oauth2.Token) oauth2.TokenSource {
+		return oauth2.ReuseTokenSource(t, cfg.TokenSource(ctx, t))
+	}
+}
+
+// NewCachingSource allows creating a oauth2.TokenSource that caches the results in a storage layer (provided when
+// the thing is constructed). Allows seeding the token source with a new token if there is nothing in the cache,
+// or if what is in the cache is invalid (e.g. the user has never signed in before).
+func NewCachingSource(
+	ctx context.Context,
+	tsf func(context.Context, *oauth2.Token) oauth2.TokenSource,
+	sf seeds.Seed,
+	str storage.Storage,
+) (*CachingSource, error) {
+	cs := &CachingSource{
+		ts:  nil,
+		cur: nil,
+		str: str,
+	}
+
+	var needsSeed bool
+
+	bytes, err := cs.str.Read()
+	tok := &oauth2.Token{}
+
+	if errors.Is(err, storage.ErrNotFound) {
+		needsSeed = true
+	} else if err != nil {
+		return nil, fmt.Errorf("%w: %s", ErrCacheSetupFailed, err)
+	}
+
+	if !needsSeed {
+		err := json.Unmarshal(bytes, tok)
+		if err != nil {
+			return nil, fmt.Errorf("%w: %s", ErrCacheFailure, err)
+		}
+
+		if !tok.Valid() && tok.RefreshToken == "" {
+			needsSeed = true
+		}
+	}
+
+	// If the token is not found, or the retrieved token is not valid, request a new token.
+	if needsSeed {
+		// If there is no token in the cache, we need to run the seed.
+		tok, err = sf(ctx)
+
+		if err != nil {
+			return nil, fmt.Errorf("%w: %s", ErrCacheSetupFailed, err)
+		}
+
+		// It should not be possible to receive a token that cannot be serialized to JSON, but just in case,
+		// handle this
+		bytes, err := json.Marshal(tok)
+		if err != nil {
+			return nil, fmt.Errorf("%w: %s", ErrCacheFailure, err)
+		}
+
+		// Write the seeded token into the cache
+		if err := cs.str.Write(bytes); err != nil {
+			return nil, fmt.Errorf("%w: %s", ErrCacheSetupFailed, err)
+		}
+	}
+
+	cs.cur = tok
+	cs.ts = tsf(ctx, cs.cur)
+
+	return cs, nil
+}
+
+// Token implements the oauth2.TokenSource interface, allowing the user to query a token — wherever it comes
+// from.
+func (cs *CachingSource) Token() (*oauth2.Token, error) {
+	newTok, err := cs.ts.Token()
+
+	// Here, we're not wrapping the error as we're a cache for the underlying storage. That error can be handled
+	// directly, if needed.
+	if err != nil {
+		return nil, err
+	}
+
+	if !isDifferent(cs.cur, newTok) {
+		return newTok, nil
+	}
+
+	bytes, err := json.Marshal(newTok)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := cs.str.Write(bytes); err != nil {
+		return nil, err
+	}
+
+	cs.cur = newTok
+	return newTok, nil
+}
+
+func isDifferent(a *oauth2.Token, b *oauth2.Token) bool {
+	// If they're both nil, then there is no difference
+	if a == nil && b == nil {
+		return false
+	}
+
+	// If there is one that is nil, they are for sure different.
+	if (a != nil && b == nil) || (a == nil && b != nil) {
+		return true
+	}
+
+	// If there's a different expiry, its different.
+	if a.Expiry.Sub(b.Expiry) != 0 {
+		return true
+	}
+
+	// Token Types
+	if a.AccessToken != b.AccessToken {
+		return true
+	}
+
+	if a.RefreshToken != b.RefreshToken {
+		return true
+	}
+
+	return false
+}

--- a/api/auth/tokens/source_test.go
+++ b/api/auth/tokens/source_test.go
@@ -1,0 +1,302 @@
+package tokens_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/andrewhowdencom/x40.link/api/auth/tokens"
+	"github.com/andrewhowdencom/x40.link/api/auth/tokens/seeds"
+	"github.com/andrewhowdencom/x40.link/api/auth/tokens/storage"
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/oauth2"
+)
+
+var (
+	// ErrSentinel is just to read and write hte same error
+	ErrSentinel = errors.New("a sentinel error for testing")
+)
+
+type TokenSource struct {
+	tokens []*oauth2.Token
+
+	err error
+}
+
+func (ts *TokenSource) Token() (*oauth2.Token, error) {
+	if ts.err != nil {
+		return nil, ts.err
+	}
+
+	if len(ts.tokens) == 0 {
+		return nil, ErrSentinel
+	}
+
+	var next *oauth2.Token
+	next, ts.tokens = ts.tokens[len(ts.tokens)-1], ts.tokens[:len(ts.tokens)]
+
+	return next, nil
+}
+
+func TestNewCachingSource(t *testing.T) {
+	// s* are sentinels, generated and used ot validate
+	sExpiry := time.Now().Add(time.Hour * 60)
+	sAccessToken := "I-AM-THE-ACCESS-TOKEN"
+	sRefreshToken := "I-AM-THE-REFRESH-TOKEN"
+
+	for _, tc := range []struct {
+		name string
+
+		ctx context.Context
+		cfg *oauth2.Config
+		sf  seeds.Seed
+		str storage.Storage
+
+		err error
+		tok *oauth2.Token
+	}{
+		{
+			name: "storage fails",
+			ctx:  context.Background(),
+			cfg:  &oauth2.Config{},
+			sf: func(ctx context.Context) (*oauth2.Token, error) {
+				return nil, fmt.Errorf("doesnt matter")
+			},
+
+			str: storage.NewTest(storage.WithReadError(func(t *storage.Test) error {
+				return storage.ErrStorageFailure
+			})),
+
+			err: tokens.ErrCacheSetupFailed,
+		},
+		{
+			name: "no token, seed fails",
+			ctx:  context.Background(),
+			cfg:  &oauth2.Config{},
+			sf: func(ctx context.Context) (*oauth2.Token, error) {
+				return nil, seeds.ErrFailed
+			},
+
+			str: storage.NewTest(),
+
+			err: tokens.ErrCacheSetupFailed,
+		},
+		{
+			name: "no token, seed fails to write to storage",
+			ctx:  context.Background(),
+			cfg:  &oauth2.Config{},
+			sf: func(ctx context.Context) (*oauth2.Token, error) {
+				return &oauth2.Token{
+					AccessToken:  sAccessToken,
+					RefreshToken: sRefreshToken,
+					TokenType:    "Bearer",
+					Expiry:       time.Now().Add(time.Hour),
+				}, nil
+			},
+			str: storage.NewTest(storage.WithWriteError(func(t *storage.Test, b []byte) error {
+				return storage.ErrStorageFailure
+			})),
+
+			err: tokens.ErrCacheSetupFailed,
+		},
+		{
+			name: "junk returned from storage",
+			ctx:  context.Background(),
+			cfg:  &oauth2.Config{},
+			sf: func(ctx context.Context) (*oauth2.Token, error) {
+				return nil, fmt.Errorf("doesnt matter")
+			},
+			str: storage.NewTest(storage.WithBytes([]byte("Whoops Im not JSON!"))),
+
+			err: tokens.ErrCacheFailure,
+		},
+		{
+			name: "expired token from storage",
+			ctx:  context.Background(),
+			cfg:  &oauth2.Config{},
+			sf: func(ctx context.Context) (*oauth2.Token, error) {
+				return &oauth2.Token{
+					AccessToken:  "I-AM-THE-ACCESS-TOKEN",
+					RefreshToken: "I-AM-THE-REFRESH-TOKEN",
+					TokenType:    "Bearer",
+					Expiry:       sExpiry,
+				}, nil
+			},
+
+			str: storage.NewTest(storage.WithBytes([]byte(`
+{
+	"access_token": "I-AM-AN-ACCESS-TOKEN",
+	"token_type": "Bearer",
+	"refresh_token": "",
+	"expiry": "2024-01-25T16:37:22.176803588+01:00"
+}
+			`))),
+
+			err: nil,
+			tok: &oauth2.Token{
+				AccessToken:  "I-AM-THE-ACCESS-TOKEN",
+				RefreshToken: "I-AM-THE-REFRESH-TOKEN",
+				TokenType:    "Bearer",
+				Expiry:       sExpiry,
+			},
+		},
+	} {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ts, err := tokens.NewCachingSource(tc.ctx, tc.cfg.TokenSource, tc.sf, tc.str)
+
+			assert.ErrorIs(t, err, tc.err)
+
+			if tc.tok != nil {
+				nt, _ := ts.Token()
+				assert.Equal(t, tc.tok, nt)
+			}
+		})
+	}
+}
+
+func TestTokenSource(t *testing.T) {
+	// s* are sentinels, generated and used ot validate
+	sExpiry := time.Now().Add(time.Hour * 60)
+	sAccessToken := "I-AM-THE-ACCESS-TOKEN"
+	sRefreshToken := "I-AM-THE-REFRESH-TOKEN"
+
+	for _, tc := range []struct {
+		name string
+		str  storage.Storage
+		tsf  func(ctx context.Context, t *oauth2.Token) oauth2.TokenSource
+		seed seeds.Seed
+
+		tok *oauth2.Token
+		err error
+	}{
+		{
+			name: "underlying token source failure",
+			str:  storage.NewTest(),
+
+			tsf: func(ctx context.Context, t *oauth2.Token) oauth2.TokenSource {
+				return &TokenSource{
+					err: ErrSentinel,
+				}
+			},
+			seed: func(ctx context.Context) (*oauth2.Token, error) {
+				return &oauth2.Token{
+					AccessToken:  sAccessToken,
+					RefreshToken: sRefreshToken,
+					TokenType:    "Bearer",
+					Expiry:       sExpiry,
+				}, nil
+			},
+
+			err: ErrSentinel,
+		},
+		{
+			name: "provided token is exactly the same",
+			str:  storage.NewTest(),
+			seed: func(ctx context.Context) (*oauth2.Token, error) {
+				return &oauth2.Token{
+					AccessToken:  sAccessToken,
+					RefreshToken: sRefreshToken,
+					TokenType:    "Bearer",
+					Expiry:       sExpiry,
+				}, nil
+			},
+			tsf: func(ctx context.Context, t *oauth2.Token) oauth2.TokenSource {
+				return &TokenSource{
+					tokens: []*oauth2.Token{
+						{
+							AccessToken:  sAccessToken,
+							RefreshToken: sRefreshToken,
+							TokenType:    "Bearer",
+							Expiry:       sExpiry,
+						},
+					},
+				}
+			},
+
+			tok: &oauth2.Token{
+				AccessToken:  sAccessToken,
+				RefreshToken: sRefreshToken,
+				TokenType:    "Bearer",
+				Expiry:       sExpiry,
+			},
+		},
+		{
+			name: "token different, but storage failed",
+			str: storage.NewTest(storage.WithWriteError(func(t *storage.Test, b []byte) error {
+				// The initial write is empty, and contains only the JSON and metadata. Given this, we skip the error
+				// if this is teh write.
+				if len(b) < 60 {
+					return nil
+				}
+
+				return ErrSentinel
+			})),
+			seed: func(ctx context.Context) (*oauth2.Token, error) {
+				return &oauth2.Token{}, nil
+			},
+			tsf: func(ctx context.Context, t *oauth2.Token) oauth2.TokenSource {
+				return &TokenSource{
+					tokens: []*oauth2.Token{
+						{
+							AccessToken:  sAccessToken,
+							RefreshToken: sRefreshToken,
+							TokenType:    "Bearer",
+							Expiry:       sExpiry,
+						},
+					},
+				}
+			},
+			tok: nil,
+			err: ErrSentinel,
+		},
+		{
+			name: "token different, all good",
+			str:  storage.NewTest(),
+			seed: func(ctx context.Context) (*oauth2.Token, error) {
+				return &oauth2.Token{}, nil
+			},
+			tsf: func(ctx context.Context, t *oauth2.Token) oauth2.TokenSource {
+				return &TokenSource{
+					tokens: []*oauth2.Token{
+						{
+							AccessToken:  sAccessToken,
+							RefreshToken: sRefreshToken,
+							TokenType:    "Bearer",
+							Expiry:       sExpiry,
+						},
+					},
+				}
+			},
+			tok: &oauth2.Token{
+				AccessToken:  sAccessToken,
+				RefreshToken: sRefreshToken,
+				TokenType:    "Bearer",
+				Expiry:       sExpiry,
+			},
+		},
+	} {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			cs, err := tokens.NewCachingSource(
+				context.Background(),
+				tc.tsf,
+				tc.seed,
+				tc.str,
+			)
+
+			assert.Nil(t, err)
+
+			tok, err := cs.Token()
+
+			assert.Equal(t, tc.tok, tok)
+			assert.ErrorIs(t, err, tc.err)
+		})
+	}
+}

--- a/api/auth/tokens/storage/test.go
+++ b/api/auth/tokens/storage/test.go
@@ -1,0 +1,80 @@
+package storage
+
+import "sync"
+
+// Test storage is just storage that is useful to make assertions in tests. Do not use it in production; there are
+// better tools for everything you could possibly do with this.
+type Test struct {
+	bytes []byte
+
+	mu *sync.RWMutex
+
+	err interface{}
+}
+
+// WithReadError sets the error for the read function to return.
+func WithReadError(in func(*Test) error) func(t *Test) {
+	return func(t *Test) {
+		t.err = in
+	}
+}
+
+// WithWriteError sets the error for the write function to return
+func WithWriteError(in func(*Test, []byte) error) func(t *Test) {
+	return func(t *Test) {
+		t.err = in
+	}
+}
+
+// WithBytes sets the initial state of the storage.
+func WithBytes(b []byte) func(t *Test) {
+	return func(t *Test) {
+		t.bytes = b
+	}
+}
+
+// NewTest generates a new test storage
+func NewTest(f ...func(t *Test)) *Test {
+	nt := &Test{
+		mu: &sync.RWMutex{},
+	}
+
+	for _, dof := range f {
+		dof(nt)
+	}
+
+	return nt
+}
+
+// Read implements storage.Read
+func (t *Test) Read() ([]byte, error) {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+
+	if f, ok := t.err.(func(*Test) error); ok {
+		if err := f(t); err != nil {
+			return nil, err
+		}
+	}
+
+	if t.bytes == nil || len(t.bytes) == 0 {
+		return nil, ErrNotFound
+	}
+
+	return t.bytes, nil
+}
+
+// Write implements storage.Write
+func (t *Test) Write(input []byte) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if f, ok := t.err.(func(*Test, []byte) error); ok {
+		if err := f(t, input); err != nil {
+			return err
+		}
+	}
+
+	t.bytes = input
+	return nil
+}


### PR DESCRIPTION
In order to have a client application persist through multiple invocations (essentially the requirement for a CLI application), the token needs to be stored outside the application in some persistence. This commit provides that persistence.

The general design of this work is to wrap a token source, and if underlying token source changes, then write that token back to storage. Then, whenever the application is reloaded, refresh the token source being used with whatever was in the cache.

This also means that there needs to be something that "seeds" the cache; for example, if the user doesn't actually have authentication just yet. To address this, a new primitive called a "Seed function" (essentially the actual authenticatino process rather than refresh) was created. This allows plugging in the auth to the token refresh cycle.

== Design Notes
=== Storage Implementations

The primary storage implementation is a file, intended to be used with a path supplied by the XDG library. This would allow storing tokens in ~/.local/share/x40/.token.json, which is a logical place for them.

There's also an implementation in memory (called "Test"), designed for ... well, testing. There's not really a limit to what other interfaces can be provided in future — I'd probably try and write a BoltDB one if this filesystem one proved buggy (so as to defer the hard™ parts to boltdb).

=== NewCacheSource

The signature for new cache source is complicated. The problem is testability — the underlying oauth library has a bunch of stuff private, which prevents assertions about its state or reuse within tests.