### PR TITLE
Reintroduce listen address configuration

### DIFF
--- a/server/wire.go
+++ b/server/wire.go
@@ -28,6 +28,10 @@ func ResolveOptions() ([]Option, error) {
 
 	opts = append(opts, WithStorage(storage))
 
+	if addr := cfg.ServerListenAddress.Value(); addr != "" {
+		opts = append(opts, WithListenAddress(addr))
+	}
+
 	if cfg.ServerH2CEnabled.Value() {
 		opts = append(opts, WithH2C())
 	}


### PR DESCRIPTION
Currently, the application is not allowing the listen address to be set.
This means that deployments to cloud are failing, as there's nothing to
send traffic to.
