### PR TITLE
fix(cli): renew token on refresh

### DIFF
--- a/cli/auth/per_rpc_creds.go
+++ b/cli/auth/per_rpc_creds.go
@@ -1,0 +1,40 @@
+// Package auth provides facilities to generate the auth required for connecting to the API
+package auth
+
+import (
+	"context"
+
+	"golang.org/x/oauth2"
+)
+
+// perRPCCredentials is an implementation of the PerRPCCredentials interface, allowing each
+// gRPC call to have the required Authorization header injected.
+type perRPCCredentials struct {
+	ts oauth2.TokenSource
+}
+
+// GetRequestMetadata implements the PerRPCCredentials interface, allowing the user to get the required
+// request metadata.
+func (p *perRPCCredentials) GetRequestMetadata(_ context.Context, _ ...string) (map[string]string, error) {
+	tok, err := p.ts.Token()
+	if err != nil {
+		return nil, err
+	}
+
+	return map[string]string{
+		"Authorization": "Bearer " + tok.AccessToken,
+	}, nil
+}
+
+// RequireTransportSecurity implements the PerRPCCredentials interface, allowing the user to determine
+// whether transport security is required.
+func (p *perRPCCredentials) RequireTransportSecurity() bool {
+	return true
+}
+
+// NewPerRPCCredentials creates a new PerRPCCredentials that can be used with a gRPC client
+func NewPerRPCCredentials(ts oauth2.TokenSource) *perRPCCredentials {
+	return &perRPCCredentials{
+		ts: ts,
+	}
+}


### PR DESCRIPTION
The command-line tool did not renew the authentication token when it expired. This was because the token was fetched only once at the start of the command and was not refreshed for subsequent gRPC calls.

This change fixes the issue by using `grpc.PerRPCCredentials` to automatically handle token refreshes. A new `perRPCCredentials` type is introduced that wraps the `oauth2.TokenSource`. This ensures that a valid token is fetched for each gRPC request, and the token is refreshed if it has expired.