### PR TITLE
ci: Upgrade GitHub Actions runners to Ubuntu 24.04

### DIFF
--- a/.github/workflows/main+documentation.yml
+++ b/.github/workflows/main+documentation.yml
@@ -15,7 +15,7 @@ jobs:
 
     # The machine type on which the workload is running
     # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#choosing-github-hosted-runners
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout the main branch
         uses: actions/checkout@v4
@@ -76,7 +76,7 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: "Deploy to GitHub pages"
         uses: actions/deploy-pages@v4

--- a/.github/workflows/main+x40.link.yml
+++ b/.github/workflows/main+x40.link.yml
@@ -12,7 +12,7 @@ jobs:
     #
     # These machines come with podman pre-installed
     # See https://github.com/redhat-actions/podman-login?tab=readme-ov-file#podman-login
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     # The environment to which main is deployed
     environment:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -23,6 +23,14 @@ jobs:
     # See https://github.com/actions/checkout
     - uses: actions/checkout@v4
 
+    # Install Java
+    # See https://github.com/actions/setup-java
+    - name: Set up Java 21
+      uses: actions/setup-java@v4
+      with:
+        java-version: '21'
+        distribution: 'temurin'
+
     # Install Go
     # See https://github.com/actions/setup-go
     - name: Set up Go

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -16,7 +16,7 @@ jobs:
     name: "test"
     # The machine type on which the workload is running
     # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#choosing-github-hosted-runners
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
 
     # Check out the head of the main branch


### PR DESCRIPTION
This commit updates the GitHub Actions workflow
files to use Ubuntu 24.04 instead of Ubuntu 22.04, as it is the latest LTS version available for
GitHub-hosted runners.